### PR TITLE
feature:OSIS-3 Enable Springboot Actuator for healthcheck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ configure(allprojects) {
         compile "org.springframework.boot:spring-boot-starter-data-jpa:$springBootVersion"
         compile "org.springframework.boot:spring-boot-starter-security:$springBootVersion"
         compile "org.springframework.boot:spring-boot-starter-data-redis:$springBootVersion"
+        compile "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
         testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }

--- a/osis-app/src/main/java/com/scality/osis/healthcheck/VaultHealthIndicator.java
+++ b/osis-app/src/main/java/com/scality/osis/healthcheck/VaultHealthIndicator.java
@@ -1,0 +1,49 @@
+/**
+ *Copyright 2021 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.healthcheck;
+
+import com.scality.osis.ScalityAppEnv;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+import java.net.HttpURLConnection;
+
+@Component("vault")
+public class VaultHealthIndicator implements HealthIndicator {
+    private static final Logger logger = LoggerFactory.getLogger(VaultHealthIndicator.class);
+
+    @Autowired
+    private ScalityAppEnv appEnv;
+
+    @Override
+    public Health health() {
+        HttpURLConnection connection = null;
+        try {
+            // check if Vault Admin Endpoint is reachable
+            connection = (HttpURLConnection) new java.net.URL(appEnv.getPlatformEndpoint()).openConnection();
+            connection.setConnectTimeout(appEnv.getVaultHealthCheckTimeout());
+            connection.connect();
+
+            // check if Vault S3 Interface Endpoint is reachable
+            connection = (HttpURLConnection) new java.net.URL(appEnv.getS3InterfaceEndpoint()).openConnection();
+            connection.setConnectTimeout(appEnv.getVaultHealthCheckTimeout());
+            connection.connect();
+        } catch (Exception e) {
+            logger.warn("Failed to connect to Vault endpoint: {}",appEnv.getPlatformEndpoint());
+            return Health.down()
+                    .withDetail("error", e.getMessage())
+                    .build();
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        return Health.up().build();
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
+++ b/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
@@ -24,6 +24,7 @@ import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_COR
 import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_MAX_POOL_SIZE;
 import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_QUEUE_CAPACITY;
 import static com.scality.osis.utils.ScalityConstants.DEFAULT_SPRING_CACHE_TYPE;
+import static com.scality.osis.utils.ScalityConstants.DEFAULT_VAULT_HEALTHCHECK_TIMEOUT;
 
 @Component
 @Primary
@@ -169,5 +170,13 @@ public class ScalityAppEnv extends AppEnv {
 
     public String getMasterKeyFilePath() {
         return env.getProperty("osis.scality.vault.master-keyfile-path");
+    }
+
+    public int getVaultHealthCheckTimeout() {
+        String vaultHealthCheckTimeout =  env.getProperty("osis.scality.vault.healthcheck.timeout");
+        if(StringUtils.isBlank(vaultHealthCheckTimeout)) {
+            vaultHealthCheckTimeout = DEFAULT_VAULT_HEALTHCHECK_TIMEOUT;
+        }
+        return Integer.parseInt(vaultHealthCheckTimeout);
     }
 }

--- a/osis-core/src/main/java/com/scality/osis/security/config/ScalityOsisBasicWebSecurityConfigurerAdapter.java
+++ b/osis-core/src/main/java/com/scality/osis/security/config/ScalityOsisBasicWebSecurityConfigurerAdapter.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.security.config;
+
+import com.vmware.osis.security.basic.BasicAuthentication;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+import static com.scality.osis.utils.ScalityConstants.HEALTH_CHECK_ENDPOINT;
+import static com.vmware.osis.security.jwt.AuthConstants.API_INFO;
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+
+@Configuration
+@EnableWebSecurity
+@ConditionalOnProperty(value = "security.jwt.enabled",
+        havingValue = "false",
+        matchIfMissing = false)
+@Order(HIGHEST_PRECEDENCE)
+public class ScalityOsisBasicWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private BasicAuthentication authentication;
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        http.cors().and().csrf().disable();
+        http.authorizeRequests().antMatchers(API_INFO).permitAll();
+        http.authorizeRequests().antMatchers(HEALTH_CHECK_ENDPOINT).permitAll();
+        http.authorizeRequests().anyRequest().authenticated();
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.httpBasic().authenticationEntryPoint(authentication);
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -92,6 +92,9 @@ public final class ScalityConstants {
     public static final String DEFAULT_ASYNC_EXECUTOR_MAX_POOL_SIZE = "10";
     public static final String DEFAULT_ASYNC_EXECUTOR_QUEUE_CAPACITY = "500";
 
+    public static final String DEFAULT_VAULT_HEALTHCHECK_TIMEOUT = "3000";
+    public static final String HEALTH_CHECK_ENDPOINT = "/_/healthcheck";
+
     public static final String USER_POLICY_ARN_REGEX = "arn:aws:iam::$ACCOUNTID:policy/userPolicy@$ACCOUNTID";
 
     public static final String USER_POLICY_NAME_REGEX = "userPolicy@$ACCOUNTID";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,7 @@ osis.scality.vault.admin-file-path=/vaultconf/admin-creds.json.encrypted
 osis.scality.vault.master-keyfile-path=/vaultconf/credentials/keyfile
 # If `decrypt-admin-credentials=false`, `secret-key` must be provided otherwise ignored
 osis.scality.vault.secret-key=UEEu8tYlsOGGrgf4DAiSZD6apVNPUWqRiPG0nTB6
+osis.scality.vault.healthcheck.timeout=3000
 
 # Vault cache config
 osis.scality.vault.cache.listAccounts.disabled=false
@@ -82,3 +83,21 @@ spring.redis.sentinel.master=mymaster
 spring.redis.sentinel.nodes=localhost:26379, localhost:26380, localhost:26381
 spring.redis.lettuce.shutdown-timeout=200ms
 osis.scality.redis.credentials.hashKey=s3credentials
+
+# Actuator config
+management.endpoints.web.exposure.include=loggers,health,metrics,threaddump
+management.endpoints.web.discovery.enabled=true
+management.endpoints.enabled-by-default=false
+management.endpoints.web.base-path=/_
+management.endpoints.web.path-mapping.health=healthcheck
+## Health check config
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=always
+management.health.defaults.enabled=false
+management.health.redis.enabled=true
+## Actuator Logger config
+management.endpoint.loggers.enabled=true
+## Actuator Metrics config
+management.endpoint.metrics.enabled=false
+## Actuator Thread dump config
+management.endpoint.threaddump.enabled=false


### PR DESCRIPTION
**Description:**
* Enable Springboot Actuator
* Enable Healthcheck endpoint of actuator
* Allow healthcheck API with no Auth headers
* Allow Actuator loggers functionality with Auth
* Add and disable metrics, threaddump

Health check Endpoint will be `https://{OSIS_URL}/_/healthcheck`

**Example Request and Response of Healthcheck**

Request:
```sh
curl -k --location --request GET 'https://localhost:8443/_/healthcheck'
```

Response:
```json
{
    "status": "UP",
    "components": {
        "redis": {
            "status": "UP",
            "details": {
                "version": "6.2.1"
            }
        },
        "vault": {
            "status": "UP"
        }
    }
}
```