### PR TITLE
Improvement: OSIS-29 query users more filter params

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -16,14 +16,20 @@ public final class ScalityConstants {
 
     public static final String DISPLAY_NAME_PREFIX = "display_name==";
 
+    public static final String USERNAME_PREFIX = "username==";
+
     public static final String TENANT_ID_PREFIX = "tenant_id==";
 
     public static final String USER_ID_PREFIX = "user_id==";
 
+    public static final String CD_USER_ID_PREFIX = "cd_user_id==";
+
     public static final String OSIS_TENANT_ID = "tenant_id";
     public static final String CD_TENANT_ID = "cd_tenant_id";
+    public static final String CD_USER_ID = "cd_user_id";
     public static final String OSIS_USER_ID = "user_id";
     public static final String DISPLAY_NAME = "display_name";
+    public static final String USERNAME = "username";
     public static final String OSIS_ACCESS_KEY = "access_key";
 
     public static final String ROLE_ARN_FORMAT = "arn:aws:iam::$ACCOUNTID:role/$ROLENAME";

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -596,6 +596,27 @@ public final class ScalityModelConverter {
     }
 
     /**
+     * Converts IAM get user response to OSIS page of users
+     *
+     * @param osisUser the osis users dto
+     * @param offset
+     * @param limit
+     * @return the page of users
+     */
+    public static PageOfUsers toPageOfUsers(OsisUser osisUser, long offset, long limit) {
+
+        PageInfo pageInfo = new PageInfo();
+        pageInfo.setLimit(limit);
+        pageInfo.setOffset(offset);
+        pageInfo.setTotal(1l);
+
+        PageOfUsers pageOfUsers = new PageOfUsers();
+        pageOfUsers.items(Collections.singletonList(osisUser));
+        pageOfUsers.setPageInfo(pageInfo);
+        return pageOfUsers;
+    }
+
+    /**
      * Converts IAM List access keys response to OSIS S3 Credentials
      *
      * @param listAccessKeysResult the list access keys response dto

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
@@ -171,6 +171,69 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
     }
 
     @Test
+    public void testQueryUsersFilterWithUsername() {
+        // Setup
+        final long offset = 0L;
+        final long limit = 1000L;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + USERNAME_PREFIX + TEST_NAME;
+
+        when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
+
+        // Run the test
+        final PageOfUsers response = scalityOsisServiceUnderTest.queryUsers(offset, limit, filter);
+
+        // Verify the results
+        assertEquals(1, response.getPageInfo().getTotal());
+        assertEquals(offset, response.getPageInfo().getOffset());
+        assertEquals(limit, response.getPageInfo().getLimit());
+        assertEquals(1, response.getItems().size());
+        assertEquals(TEST_NAME, response.getItems().get(0).getUsername());
+        assertTrue(response.getItems().get(0).getTenantId().contains(SAMPLE_TENANT_ID));
+    }
+
+    @Test
+    public void testQueryUsersFilterWithUserid() {
+        // Setup
+        final long offset = 0L;
+        final long limit = 1000L;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + USER_ID_PREFIX + TEST_USER_ID;
+
+        when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
+
+        // Run the test
+        final PageOfUsers response = scalityOsisServiceUnderTest.queryUsers(offset, limit, filter);
+
+        // Verify the results
+        assertEquals(1, response.getPageInfo().getTotal());
+        assertEquals(offset, response.getPageInfo().getOffset());
+        assertEquals(limit, response.getPageInfo().getLimit());
+        assertEquals(1, response.getItems().size());
+        assertEquals(TEST_USER_ID, response.getItems().get(0).getUserId());
+        assertTrue(response.getItems().get(0).getTenantId().contains(SAMPLE_TENANT_ID));
+    }
+
+    @Test
+    public void testQueryUsersFilterWithCdUserid() {
+        // Setup
+        final long offset = 0L;
+        final long limit = 1000L;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + CD_USER_ID_PREFIX + TEST_USER_ID;
+
+        when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
+
+        // Run the test
+        final PageOfUsers response = scalityOsisServiceUnderTest.queryUsers(offset, limit, filter);
+
+        // Verify the results
+        assertEquals(1, response.getPageInfo().getTotal());
+        assertEquals(offset, response.getPageInfo().getOffset());
+        assertEquals(limit, response.getPageInfo().getLimit());
+        assertEquals(1, response.getItems().size());
+        assertEquals(TEST_USER_ID, response.getItems().get(0).getUserId());
+        assertTrue(response.getItems().get(0).getTenantId().contains(SAMPLE_TENANT_ID));
+    }
+
+    @Test
     public void testQueryUsersWithNonUUID() {
         // Setup
         final long offset = 0L;

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -476,6 +476,32 @@ public class ScalityModelConverterTest {
     }
 
     @Test
+    public void testToPageOfUsers2() {
+        // Setup
+        final OsisUser osisUser = new OsisUser();
+        osisUser.setCanonicalUserId(TEST_CANONICAL_ID);
+        osisUser.setTenantId(TEST_TENANT_ID);
+        osisUser.setActive(true);
+        osisUser.setUsername(TEST_NAME);
+        osisUser.setCdUserId(TEST_USER_ID);
+        osisUser.setUserId(TEST_USER_ID);
+        osisUser.setRole(OsisUser.RoleEnum.TENANT_USER);
+        osisUser.setEmail(SAMPLE_SCALITY_USER_EMAIL);
+        osisUser.setCdTenantId(TEST_TENANT_ID);
+
+        // Run the test
+        final PageOfUsers pageOfUsers = ScalityModelConverter.toPageOfUsers(osisUser, 0, 1000);
+
+        // Verify the results
+        assertEquals(pageOfUsers.getItems().size(), 1);
+        assertNotNull(pageOfUsers.getPageInfo());
+
+        final OsisUser resUser = pageOfUsers.getItems().get(0);
+
+        assertEquals(osisUser, resUser);
+    }
+
+    @Test
     public void testExtractCdTenantId() {
         // Setup
         final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID ;


### PR DESCRIPTION
`query-users` API has some parameters missing in the `filter`
1. Add filter param `username`
2. Add filter param `cd_user_id`
3. Add filter param `user_id`