### PR TITLE
bugfix:OSIS-33 Support multiple admin files

### DIFF
--- a/vault-admin-client/src/main/java/com/scality/osis/security/crypto/model/EncryptedAdminCredentials.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/security/crypto/model/EncryptedAdminCredentials.java
@@ -7,6 +7,7 @@ package com.scality.osis.security.crypto.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,6 +17,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@EqualsAndHashCode
 public class EncryptedAdminCredentials {
     String salt;
     String tag;

--- a/vault-admin-client/src/main/java/com/scality/osis/security/utils/SecurityConstants.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/security/utils/SecurityConstants.java
@@ -6,5 +6,6 @@ public class SecurityConstants {
     public static final String NAME_AES_256_GCM_CIPHER = "AES256GCM";
     public final static int DEFAULT_AES_GCM_NONCE_LENGTH = 12;
     public final static int DEFAULT_AES_GCM_TAG_LENGTH = 128; //128 bit auth tag length
+    public final static int DEFAULT_AES_GCM_TAG_LENGTH_IN_BYTES = 16; //16 byte auth tag length
     public final static int DEFAULT_AES_GCM_256_KEY_LENGTH = 32; //128 bit auth tag length
 }

--- a/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/VaultAdminUtils.java
+++ b/vault-admin-client/src/main/java/com/scality/osis/vaultadmin/utils/VaultAdminUtils.java
@@ -25,7 +25,17 @@ public class VaultAdminUtils {
             final Type listType = new TypeToken<List<EncryptedAdminCredentials>>() {}.getType();
             final List<EncryptedAdminCredentials> encryptedAdminCredentialsList = new Gson().fromJson(adminFileContent, listType);
 
-            return new AES256GCM().decryptHKDF(masterKeyFile, encryptedAdminCredentialsList.get(0), accessKey);
+            for(EncryptedAdminCredentials adminCredentials : encryptedAdminCredentialsList) {
+                AES256GCM aes256GCM = new AES256GCM();
+                String sk = aes256GCM.decryptHKDF(masterKeyFile, adminCredentials, accessKey);
+
+                // Encrypt the decrypted value to verify if correct SK
+                if(adminCredentials.equals(aes256GCM.encryptHKDF(masterKeyFile, adminCredentials.getSalt(), sk, accessKey))){
+                    // return when correct SK if found
+                    return sk;
+                }
+            }
+            return null;
         }
         catch (Exception e) {
             return null;

--- a/vault-admin-client/src/test/java/com/scality/osis/security/crypto/AES256GCMTest.java
+++ b/vault-admin-client/src/test/java/com/scality/osis/security/crypto/AES256GCMTest.java
@@ -99,4 +99,21 @@ public class AES256GCMTest {
         // Run the test
         assertThrows(AEADBadTagException.class, () -> aes256GCMUnderTest.decryptHKDF(TEST_MASTER_KEY, encryptedAdminCredentialsList.get(0),"InvalidData" ));
     }
+
+    @Test
+    public void testEncryptHKDF() throws Exception {
+        // Setup
+        //create EncryptedAdminCredentials from json file
+        final Type listType = new TypeToken<List<EncryptedAdminCredentials>>() {}.getType();
+        final List<EncryptedAdminCredentials> encryptedAdminCredentialsList = new Gson().fromJson(TEST_ADMIN_CREDS_FILE, listType);
+
+
+        // Run the test
+        final EncryptedAdminCredentials result = aes256GCMUnderTest.encryptHKDF(TEST_MASTER_KEY, encryptedAdminCredentialsList.get(0).getSalt(),
+                TEST_ADMIN_SECRET_KEY, TEST_ADMIN_ACCESS_KEY );
+
+        assertEquals(encryptedAdminCredentialsList.get(0).getValue(), result.getValue());
+        assertEquals(encryptedAdminCredentialsList.get(0).getSalt(), result.getSalt());
+        assertEquals(encryptedAdminCredentialsList.get(0).getTag(), result.getTag());
+    }
 }


### PR DESCRIPTION
Description:
OSIS decrypts vault admin file to extract SK. When multiple admin files exist, encrypted file will have both keys. This commit fixes by verifying decrypted value