### PR TITLE
improvement: OSIS-45-fix CVE-2020-1938

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ keytool \
 2. `./gradlew bootJar`
 3. `java -jar -Dserver.tomcat.basedir=tomcat -Dserver.tomcat.accesslog.directory=logs -Dserver.tomcat.accesslog.enabled=true build/libs/osis-scality-[CURRENT_VERSION].jar`
 
+### Scan for vulnerabilities
+
+- `./gradlew dependencyCheckAnalyze`: Runs dependency-check against the project and generates a report under `build/reports`
+- `./gradlew dependencyCheckUpdate`: Updates the local cache of the NVD data from NIST.
+- `./gradlew dependencyCheckPurge`: Deletes the local copy of the NVD. This is used to force a refresh of the data.
+- More configuration options: <https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html>
 
 ## Verify the Implementation (Developers Only)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.2.4.RELEASE'
+        springBootVersion = '2.2.5.RELEASE'
     }
     repositories {
         mavenCentral()
@@ -101,7 +101,7 @@ sourceSets {
 
 configure(allprojects) {
     ext {
-        springBootVersion = '2.2.4.RELEASE'
+        springBootVersion = '2.2.5.RELEASE'
     }
     dependencies {
         compile "org.springframework.boot:spring-boot-starter-webflux:$springBootVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
         classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
+        classpath 'org.owasp:dependency-check-gradle:7.1.1'
     }
 }
 
@@ -37,6 +38,7 @@ dependencies {
 allprojects {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
+    apply plugin: 'org.owasp.dependencycheck'
 
     apply from: "$rootDir/spotbugs.gradle"
     apply from: "$rootDir/pmd.gradle"


### PR DESCRIPTION
This PR is in response to [CVES-113](https://scality.atlassian.net/browse/CVES-113) for [CVE-2020-1938](https://nvd.nist.gov/vuln/detail/CVE-2020-1938)

[Commit # 1](https://github.com/scality/osis/commit/f9008236917f886e55d19b730b1b7a1f1574e704)
- This commit adds the dependency checker plugin, later it will be enabled in the CI
- Dependency-Check is a Software Composition Analysis (SCA) tool that attempts to detect publicly disclosed vulnerabilities contained within a project’s dependencies. It does this by determining if there is a Common Platform Enumeration (CPE) identifier for a given dependency. If found, it will generate a report linking to the associated CVE entries.
- OWASP dependency-check gradle plugin is a software composition analysis tool used to find known vulnerable dependencies.
- More details: https://owasp.org/www-project-dependency-check/

[Commit # 2](https://github.com/scality/osis/commit/4bc03b3b35a67003a0fc23867f4e26f3d352434b)
- Updates spring boot version from v2.2.4 to v2.2.5
- The new version of embeds tomcat v9.0.31 which fixes https://github.com/advisories/GHSA-c9hw-wf7x-jp9j
- Change log: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot/2.2.5.RELEASE
- CVES ticket: https://scality.atlassian.net/browse/CVES-113

Note for reviewers:
I will wait for the product team's confirmation on when to release a new image but should be reviewable.