### PR TITLE
improvement: OSIS-49-fix-CVE-2019-8457

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle bootJar
 
-FROM openjdk:8-jdk-alpine AS build-image
+FROM amazoncorretto:8-alpine-jdk AS build-image
 EXPOSE 8443
 RUN apk add --no-cache bash
 COPY --from=gradle-build /home/gradle/src/build/libs/osis-scality-*.jar /app/lib/app.jar


### PR DESCRIPTION
We are moving away from openjdk as alpine is not supported now. The OpenJDK port
for Alpine is not in a supported release by OpenJDK, since it is not in the
mainline code base. It is only available as early access builds of OpenJDK
Project Portola.
https://github.com/docker-library/openjdk/pull/235#issuecomment-424599754

Fixes CVE-2019-8457 reported in https://scality.atlassian.net/browse/CVES-31