### PR TITLE
improvement: OSIS-50-update-tag-for-release-v0.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
 }
 
 group = 'com.scality'
-version '0.4.0'
+version '0.4.1'
 description = 'osis.scality'
 sourceCompatibility = '1.8'
 
@@ -155,7 +155,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId 'com.scality'
             artifactId 'osis'
-            version '0.4.0'
+            version '0.4.1'
 
             from components.java
 

--- a/osis-app/build.gradle
+++ b/osis-app/build.gradle
@@ -10,4 +10,4 @@ dependencies {
 }
 jar.enabled(true)
 group = 'com.scality'
-version '0.4.0'
+version '0.4.1'

--- a/osis-core/build.gradle
+++ b/osis-core/build.gradle
@@ -5,4 +5,4 @@ test {
     useJUnitPlatform()
 }
 group = 'com.scality'
-version '0.4.0'
+version '0.4.1'

--- a/vault-admin-client/build.gradle
+++ b/vault-admin-client/build.gradle
@@ -38,7 +38,7 @@ test {
 }
 
 group = 'com.scality'
-version = '0.4.0'
+version = '0.4.1'
 description = 'osis-vault-admin'
 sourceCompatibility = '1.8'
 


### PR DESCRIPTION
Updates tag to OSIS v0.4.1 contains fix for CVE-2019-8457