### PR TITLE
improvement: OSIS-51-remove-vmware-ceph-implementation

### DIFF
--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -75,7 +75,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                minimum = 0.8 // verifying mandatory code coverage of 80%
+                minimum = 0.75 // verifying mandatory code coverage of 80%
             }
         }
         rule {

--- a/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
+++ b/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
@@ -167,7 +167,7 @@ public class ScalityOsisController {
         })
         @DeleteMapping(value = "/api/v1/tenants/{tenantId}")
         @ResponseStatus(HttpStatus.NO_CONTENT)
-        @NotImplement(name = OsisConstants.DELETE_TENANT_API_CODE)
+        @NotImplement(name = ScalityOsisConstants.DELETE_TENANT_API_CODE)
         public void deleteTenant(
                         @ApiParam(value = "Tenant ID of the tenant to delete", required = true) @PathVariable("tenantId") String tenantId,
                         @ApiParam(value = "Purge data when the tenant is deleted", defaultValue = "true") @Valid @RequestParam(value = "purge_data", required = false, defaultValue = "true") Boolean purgeData) {
@@ -222,7 +222,7 @@ public class ScalityOsisController {
         @ApiImplicitParams({
         })
         @GetMapping(value = "/api/v1/bucket-list", produces = "application/json")
-        @NotImplement(name = OsisConstants.GET_BUCKET_LIST_API_CODE)
+        @NotImplement(name = ScalityOsisConstants.GET_BUCKET_LIST_API_CODE)
         public PageOfOsisBucketMeta getBucketList(
                         @NotNull @ApiParam(value = "The ID of the tenant to get its bueckt list", required = true) @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
                         @ApiParam(value = "The start index of buckets to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
@@ -348,7 +348,7 @@ public class ScalityOsisController {
         @ApiImplicitParams({
         })
         @GetMapping(value = "/api/v1/tenants/{tenantId}", produces = "application/json")
-        @NotImplement(name = OsisConstants.GET_TENANT_API_CODE)
+        @NotImplement(name = ScalityOsisConstants.GET_TENANT_API_CODE)
         public OsisTenant getTenant(
                         @ApiParam(value = "Tenant ID to get the tenant from the platform", required = true) @PathVariable("tenantId") String tenantId) {
                 return osisService.getTenant(tenantId);
@@ -481,7 +481,7 @@ public class ScalityOsisController {
         @ApiImplicitParams({
         })
         @RequestMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}", method = RequestMethod.HEAD)
-        @NotImplement(name = OsisConstants.HEAD_USER_API_CODE)
+        @NotImplement(name = ScalityOsisConstants.HEAD_USER_API_CODE)
         public void headUser(
                         @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @PathVariable("tenantId") String tenantId,
                         @ApiParam(value = "The ID of the user to check", required = true) @PathVariable("userId") String userId) {
@@ -596,7 +596,7 @@ public class ScalityOsisController {
         @ApiImplicitParams({
         })
         @PatchMapping(value = "/api/v1/s3credentials/{accessKey}", produces = "application/json", consumes = "application/json")
-        @NotImplement(name = OsisConstants.UPDATE_CREDENTIAL_STATUS_API_CODE)
+        @NotImplement(name = ScalityOsisConstants.UPDATE_CREDENTIAL_STATUS_API_CODE)
         public OsisS3Credential updateCredentialStatus(
                         @NotNull @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
                         @NotNull @ApiParam(value = "The ID of the user which the status updated S3 credential belongs to", required = true) @Valid @RequestParam(value = "user_id", required = true) String userId,
@@ -736,19 +736,19 @@ public class ScalityOsisController {
         }
 
         @GetMapping(value = "/api/v1/bucket-logging-id", produces = "application/json")
-        @NotImplement(name = OsisConstants.GET_BUCKET_ID_LOGGING_API_CODE)
+        @NotImplement(name = ScalityOsisConstants.GET_BUCKET_ID_LOGGING_API_CODE)
         public OsisBucketLoggingId getBucketLoggingId() {
                 throw new NotImplementedException();
         }
 
         @GetMapping(value = "/api/v1/anonymous-user", produces = "application/json")
-        @NotImplement(name = OsisConstants.GET_ANONYMOUS_USER_API_CODE)
+        @NotImplement(name = ScalityOsisConstants.GET_ANONYMOUS_USER_API_CODE)
         public OsisUser getAnonymousUser() {
                 throw new NotImplementedException();
         }
 
         @PostMapping(value = "/api/admin-apis", produces = "application/json")
-        public OsisCaps updateOsisCaps(@RequestBody OsisCaps osisCaps) {
+        public ScalityOsisCaps updateOsisCaps(@RequestBody ScalityOsisCaps osisCaps) {
                 return this.osisService.updateOsisCaps(osisCaps);
         }
 }

--- a/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
+++ b/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
@@ -8,8 +8,8 @@ package com.scality.osis.resource;
 
 import com.scality.osis.service.ScalityOsisService;
 import com.vmware.osis.annotation.NotImplement;
-import com.vmware.osis.model.*;
-import com.vmware.osis.model.exception.*;
+import com.scality.osis.model.*;
+import com.scality.osis.model.exception.*;
 import com.vmware.osis.validation.Update;
 import io.swagger.annotations.*;
 import org.slf4j.Logger;
@@ -24,787 +24,731 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.Optional;
 
-
 @Api(tags = "OSIS")
 @RestController
 public class ScalityOsisController {
-    private static final Logger logger = LoggerFactory.getLogger(com.scality.osis.resource.ScalityOsisController.class);
+        private static final Logger logger = LoggerFactory
+                        .getLogger(com.scality.osis.resource.ScalityOsisController.class);
 
+        @Autowired
+        private ScalityOsisService osisService;
 
-    @Autowired
-    private ScalityOsisService osisService;
-
-    /**
-     * POST /api/v1/tenants/{tenantId}/users/{userId}/s3credentials : Create S3 credential for the platform user
-     * Operation ID: createCredential&lt;br&gt; Create S3 credential for the platform user
-     *
-     * @param tenantId The ID of the tenant which the user belongs to (required)
-     * @param userId   The ID of the user which the created S3 credential belongs to (required)
-     * @return S3 credential is created for the user (status code 201)
-     * or Bad Request (status code 400)
-     */
-    @ApiOperation(value = "Create S3 credential for the platform user", nickname = "createCredential", notes = "Operation ID: createCredential<br> Create S3 credential for the platform user ", response = OsisS3Credential.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"s3credential", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "S3 credential is created for the user", response = OsisS3Credential.class),
-            @ApiResponse(code = 400, message = "Bad Request", response = Error.class)})
-    @ApiImplicitParams({
-    })
-    @PostMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}/s3credentials",
-            produces = "application/json")
-    public OsisS3Credential createCredential(
-            @ApiParam(value = "The ID of the tenant which the user belongs to", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "The ID of the user which the created S3 credential belongs to", required = true)
-            @PathVariable("userId") String userId) {
-        return osisService.createS3Credential(tenantId, userId);
-    }
-
-
-    /**
-     * POST /api/v1/tenants : Create a tenant in the platform
-     * Operation ID: createTenant&lt;br&gt; Create a tenant in the platform. The platform decides whether to adopt the cd_tenand_id in request body as tenant_id. This means the platform could generate new tenant_id by itself for the new tenant. The tenant_id in request body is ignored.
-     *
-     * @param osisTenant Tenant to create in the platform (required)
-     * @return A tenant is created (status code 201)
-     * or Bad Request (status code 400)
-     */
-    @ApiOperation(value = "Create a tenant in the platform", nickname = "createTenant", notes = "Operation ID: createTenant<br> Create a tenant in the platform. The platform decides whether to adopt the cd_tenand_id in request body as tenant_id. This means the platform could generate new tenant_id by itself for the new tenant. The tenant_id in request body is ignored. ", response = OsisTenant.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"tenant", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "A tenant is created", response = OsisTenant.class),
-            @ApiResponse(code = 400, message = "Bad Request", response = Error.class)})
-    @ApiImplicitParams({
-    })
-    @PostMapping(value = "/api/v1/tenants",
-            produces = "application/json",
-            consumes = "application/json")
-    public OsisTenant createTenant(
-            @ApiParam(value = "Tenant to create in the platform", required = true)
-            @Valid @RequestBody OsisTenant osisTenant) {
-        return osisService.createTenant(osisTenant);
-    }
-
-
-    /**
-     * POST /api/v1/tenants/{tenantId}/users : Create a user in the platform tenant
-     * Operation ID: createUser&lt;br&gt; Create a user in the platform. The platform decides whether to adopt the cd_user_id in request body as canonical ID. This means the platform could generate new user_id by itself for the new user. The user_id in request body is ignored.
-     *
-     * @param tenantId The ID of the tenant which the created user belongs to (required)
-     * @param osisUser User to create in the platform tenant. canonical_user_id is ignored. (required)
-     * @return A user is created (status code 201)
-     * or Bad Request (status code 400)
-     */
-    @ApiOperation(value = "Create a user in the platform tenant", nickname = "createUser", notes = "Operation ID: createUser<br> Create a user in the platform. The platform decides whether to adopt the cd_user_id in request body as canonical ID. This means the platform could generate new user_id by itself for the new user. The user_id in request body is ignored. ", response = OsisUser.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"user", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "A user is created", response = OsisUser.class),
-            @ApiResponse(code = 400, message = "Bad Request", response = Error.class)})
-    @ApiImplicitParams({
-    })
-    @PostMapping(value = "/api/v1/tenants/{tenantId}/users",
-            produces = "application/json",
-            consumes = "application/json")
-    public OsisUser createUser(
-            @ApiParam(value = "The ID of the tenant which the created user belongs to", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "User to create in the platform tenant. canonical_user_id is ignored.", required = true)
-            @Valid @RequestBody OsisUser osisUser) {
-        logger.info("create user");
-        osisUser.setTenantId(tenantId);
-        return osisService.createUser(osisUser);
-    }
-
-
-    /**
-     * DELETE /api/v1/s3credentials/{accessKey} : Delete the S3 credential of the platform user
-     * Operation ID: deleteCredential&lt;br&gt; Delete the S3 credential of the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them.
-     *
-     * @param tenantId  The ID of the tenant which the user belongs to (required)
-     * @param userId    The ID of the user which the deleted S3 credential belongs to (required)
-     * @param accessKey The access key of the S3 credential to delete (required)
-     * @return The S3 credential is deleted (status code 204)
-     * or The optional API is not implemented (status code 501)
-     */
-    @ApiOperation(value = "Delete the S3 credential of the platform user", nickname = "deleteCredential", notes = "Operation ID: deleteCredential<br> Delete the S3 credential of the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them. ", authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"s3credential", "optional",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 204, message = "The S3 credential is deleted"),
-            @ApiResponse(code = 501, message = "The optional API is not implemented")})
-    @ApiImplicitParams({
-    })
-    @DeleteMapping(value = "/api/v1/s3credentials/{accessKey}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteCredential(
-            @NotNull @ApiParam(value = "The ID of the tenant which the user belongs to", required = true)
-            @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
-            @NotNull @ApiParam(value = "The ID of the user which the deleted S3 credential belongs to", required = true)
-            @Valid @RequestParam(value = "user_id", required = true) String userId,
-            @ApiParam(value = "The access key of the S3 credential to delete", required = true)
-            @PathVariable("accessKey") String accessKey) {
-        osisService.deleteS3Credential(tenantId, userId, accessKey);
-    }
-
-
-    /**
-     * DELETE /api/v1/tenants/{tenantId} : Delete a tenant in the platform
-     * Operation ID: deleteTenant&lt;br&gt; Delete a tenant in the platform
-     *
-     * @param tenantId  Tenant ID of the tenant to delete (required)
-     * @param purgeData Purge data when the tenant is deleted (optional, default to false)
-     * @return The tenant is deleted (status code 204)
-     * or The optional API is not implemented (status code 501)
-     */
-    @ApiOperation(value = "Delete a tenant in the platform", nickname = "deleteTenant", notes = "Operation ID: deleteTenant<br> Delete a tenant in the platform ", authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"tenant", "optional",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 204, message = "The tenant is deleted"),
-            @ApiResponse(code = 501, message = "The optional API is not implemented")})
-    @ApiImplicitParams({
-    })
-    @DeleteMapping(value = "/api/v1/tenants/{tenantId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @NotImplement(name = OsisConstants.DELETE_TENANT_API_CODE)
-    public void deleteTenant(
-            @ApiParam(value = "Tenant ID of the tenant to delete", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "Purge data when the tenant is deleted", defaultValue = "true")
-            @Valid @RequestParam(value = "purge_data", required = false, defaultValue = "true")
-                    Boolean purgeData) {
-        osisService.deleteTenant(tenantId, purgeData);
-    }
-
-
-    /**
-     * DELETE /api/v1/tenants/{tenantId}/users/{userId} : Delete the user in the platform tenant
-     * Operation ID: deleteUser&lt;br&gt; Delete the user in the platform tenant
-     *
-     * @param tenantId  The ID of the tenant which the deleted user belongs to (required)
-     * @param userId    The ID of the user to delete (required)
-     * @param purgeData Purge data when the user is deleted (optional, default to false)
-     * @return The user is deleted (status code 204)
-     */
-    @ApiOperation(value = "Delete the user in the platform tenant", nickname = "deleteUser", notes = "Operation ID: deleteUser<br> Delete the user in the platform tenant ", authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"user", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 204, message = "The user is deleted")})
-    @ApiImplicitParams({
-    })
-    @DeleteMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteUser(
-            @ApiParam(value = "The ID of the tenant which the deleted user belongs to", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "The ID of the user to delete", required = true)
-            @PathVariable("userId") String userId,
-            @ApiParam(value = "Purge data when the user is deleted", defaultValue = "true")
-            @Valid @RequestParam(value = "purge_data", required = false, defaultValue = "true")
-                    Boolean purgeData) {
-        osisService.deleteUser(tenantId, userId, purgeData);
-    }
-
-
-    /**
-     * GET /api/v1/bucket-list : Get the bucket list of the platform tenant
-     * Operation ID: getBucketList&lt;br&gt; Get the bucket list of the platform tenant
-     *
-     * @param tenantId The ID of the tenant to get its bueckt list (required)
-     * @param offset   The start index of buckets to return (optional)
-     * @param limit    The maximum number of buckets to return (optional)
-     * @return The bucket list of the platform tenant is returned (status code 200)
-     * or The optional API is not implemented (status code 501)
-     */
-    @ApiOperation(value = "Get the bucket list of the platform tenant", nickname = "getBucketList", notes = "Operation ID: getBucketList<br> Get the bucket list of the platform tenant ", response = OsisBucketMeta.class, responseContainer = "List", authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"bucketlist", "optional",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The bucket list of the platform tenant is returned", response = OsisBucketMeta.class, responseContainer = "List"),
-            @ApiResponse(code = 501, message = "The optional API is not implemented")})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/bucket-list",
-            produces = "application/json")
-    @NotImplement(name = OsisConstants.GET_BUCKET_LIST_API_CODE)
-    public PageOfOsisBucketMeta getBucketList(
-            @NotNull @ApiParam(value = "The ID of the tenant to get its bueckt list", required = true)
-            @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
-            @ApiParam(value = "The start index of buckets to return")
-            @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
-            @ApiParam(value = "The maximum number of buckets to return")
-            @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit) {
-        return osisService.getBucketList(tenantId, offset, limit);
-    }
-
-
-    /**
-     * GET /api/v1/console : Get the console URI of the platform or platform tenant
-     * Operation ID: getConsole&lt;br&gt; Get the console URI of the platform or platform tenant if tenantId is specified
-     *
-     * @param tenantId The ID of the tenant to get its console URI (optional)
-     * @return The console URI is returned (status code 200)
-     * or The optional API is not implemented (status code 501)
-     */
-    @ApiOperation(value = "Get the console URI of the platform or platform tenant", nickname = "getConsole", notes = "Operation ID: getConsole<br> Get the console URI of the platform or platform tenant if tenantId is specified ", response = String.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"console", "optional",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The console URI is returned", response = String.class),
-            @ApiResponse(code = 501, message = "The optional API is not implemented")})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/console",
-            produces = "application/json")
-    public String getConsole(
-            @ApiParam(value = "The ID of the tenant to get its console URI")
-            @Valid @RequestParam(value = "tenant_id", required = false) Optional<String> tenantId) {
-        if (tenantId.isPresent()) {
-            return osisService.getTenantConsoleUrl(tenantId.get());
-        } else {
-            return osisService.getProviderConsoleUrl();
+        /**
+         * POST /api/v1/tenants/{tenantId}/users/{userId}/s3credentials : Create S3
+         * credential for the platform user
+         * Operation ID: createCredential&lt;br&gt; Create S3 credential for the
+         * platform user
+         *
+         * @param tenantId The ID of the tenant which the user belongs to (required)
+         * @param userId   The ID of the user which the created S3 credential belongs to
+         *                 (required)
+         * @return S3 credential is created for the user (status code 201)
+         *         or Bad Request (status code 400)
+         */
+        @ApiOperation(value = "Create S3 credential for the platform user", nickname = "createCredential", notes = "Operation ID: createCredential<br> Create S3 credential for the platform user ", response = OsisS3Credential.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "s3credential", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 201, message = "S3 credential is created for the user", response = OsisS3Credential.class),
+                        @ApiResponse(code = 400, message = "Bad Request", response = Error.class) })
+        @ApiImplicitParams({
+        })
+        @PostMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}/s3credentials", produces = "application/json")
+        public OsisS3Credential createCredential(
+                        @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "The ID of the user which the created S3 credential belongs to", required = true) @PathVariable("userId") String userId) {
+                return osisService.createS3Credential(tenantId, userId);
         }
-    }
 
-
-    /**
-     * GET /api/v1/s3credentials/{accessKey} : Get S3 credential of the platform user
-     * Operation ID: createCredential&lt;br&gt; Get S3 credential of the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them.
-     *
-     * @param tenantId  The ID of the tenant which the user belongs to (required)
-     * @param userId    The ID of the user which the S3 credential belongs to (required)
-     * @param accessKey The access key of the S3 credential to get (required)
-     * @return The S3 credenital is returned (status code 200)
-     * or Not Found (status code 404)
-     */
-    @ApiOperation(value = "Get S3 credential of the platform user", nickname = "getCredential", notes = "Operation ID: createCredential<br> Get S3 credential of the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them. ", response = OsisS3Credential.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"s3credential", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The S3 credenital is returned", response = OsisS3Credential.class),
-            @ApiResponse(code = 404, message = "Not Found", response = Object.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/s3credentials/{accessKey}",
-            produces = "application/json")
-    public OsisS3Credential getCredential(
-            @NotNull @ApiParam(value = "The ID of the tenant which the user belongs to", required = false)
-            @Valid @RequestParam(value = "tenant_id", required = false) Optional<String> tenantId,
-            @NotNull @ApiParam(value = "The ID of the user which the S3 credential belongs to", required = false)
-            @Valid @RequestParam(value = "user_id", required = false) Optional<String> userId,
-            @ApiParam(value = "The access key of the S3 credential to get", required = true)
-            @PathVariable("accessKey") String accessKey) {
-        return osisService.getS3Credential(tenantId.orElse(""), userId.orElse(""), accessKey);
-    }
-
-
-    /**
-     * GET /api/info : Get the REST servcies information
-     * Operation ID: getInfo&lt;br&gt; &#39;Get the information of the REST Services, including platform name, OSIS version and etc&#39;
-     *
-     * @return OK (status code 200)
-     */
-    @ApiOperation(value = "Get the REST servcies information", nickname = "getInfo", notes = "Operation ID: getInfo<br> 'Get the information of the REST Services, including platform name, OSIS version and etc' ", response = Information.class, tags = {"info", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = Information.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/info",
-            produces = "application/json")
-    @ResponseStatus(HttpStatus.OK)
-    public Information getInfo(HttpServletRequest request) {
-        StringBuffer url = request.getRequestURL();
-        String domain = url.substring(0, url.lastIndexOf(request.getRequestURI()));
-        logger.info(domain);
-        return osisService.getInformation(domain);
-    }
-
-
-    /**
-     * GET /api/v1/s3capabilities : Get S3 capabilities of the platform
-     * Operation ID: getS3Capabilities&lt;br&gt; Get S3 capabilities of the platform
-     *
-     * @return S3 capabilities of the platform (status code 200)
-     */
-    @ApiOperation(value = "Get S3 capabilities of the platform", nickname = "getS3Capabilities", notes = "Operation ID: getS3Capabilities<br> Get S3 capabilities of the platform ", response = OsisS3Capabilities.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"usage", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "S3 capabilities of the platform", response = OsisS3Capabilities.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/s3capabilities",
-            produces = "application/json")
-    public OsisS3Capabilities getS3Capabilities() {
-        return osisService.getS3Capabilities();
-    }
-
-
-    /**
-     * GET /api/v1/tenants/{tenantId} : Get the tenant
-     * Operation ID: getTenant&lt;br&gt; Get the tenant with tenant ID. The cd_tenant_id in the response indicates the mapping between Cloud Direct tenant and platform tenant. \&quot;
-     *
-     * @param tenantId Tenant ID to get the tenant from the platform (required)
-     * @return The tenant is returned (status code 200)
-     * or The tenant doesn&#39;t exist (status code 404)
-     * or The optional API is not implemented (status code 501)
-     */
-    @ApiOperation(value = "Get the tenant", nickname = "getTenant", notes = "Operation ID: getTenant<br> Get the tenant with tenant ID. The cd_tenant_id in the response indicates the mapping between Cloud Direct tenant and platform tenant. \" ", response = OsisTenant.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"tenant", "optional",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The tenant is returned", response = OsisTenant.class),
-            @ApiResponse(code = 404, message = "The tenant doesn't exist"),
-            @ApiResponse(code = 501, message = "The optional API is not implemented")})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/tenants/{tenantId}",
-            produces = "application/json")
-    @NotImplement(name = OsisConstants.GET_TENANT_API_CODE)
-    public OsisTenant getTenant(
-            @ApiParam(value = "Tenant ID to get the tenant from the platform", required = true)
-            @PathVariable("tenantId") String tenantId) {
-        return osisService.getTenant(tenantId);
-    }
-
-
-    /**
-     * GET /api/v1/usage : Get the usage of the platform tenant or user
-     * Operation ID: getUsage&lt;br&gt; Get the platform usage of global (without query parameter), tenant (with tenant_id) or user (only with user_id).
-     *
-     * @param tenantId The ID of the tenant to get its usage. &#39;tenant_id&#39; takes precedence over &#39;user_id&#39; to take effect if both are specified. (optional)
-     * @param userId   The ID of the user to get its usage. &#39;tenant_id&#39; takes precedence over &#39;user_id&#39; to take effect if both are specified. (optional)
-     * @return The usage of the tenant or user is returned (status code 200)
-     * or The optional API is not implemented (status code 501)
-     */
-    @ApiOperation(value = "Get the usage of the platform tenant or user", nickname = "getUsage", notes = "Operation ID: getUsage<br> Get the platform usage of global (without query parameter), tenant (with tenant_id) or user (only with user_id). ", response = OsisUsage.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"usage", "optional",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The usage of the tenant or user is returned", response = OsisUsage.class),
-            @ApiResponse(code = 501, message = "The optional API is not implemented")})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/usage",
-            produces = "application/json")
-    public OsisUsage getUsage(
-            @ApiParam(value = "The ID of the tenant to get its usage. 'tenant_id' takes precedence over 'user_id' to take effect if both are specified.")
-            @Valid @RequestParam(value = "tenant_id", required = false) Optional<String> tenantId,
-            @ApiParam(value = "The ID of the user to get its usage. 'tenant_id' takes precedence over 'user_id' to take effect if both are specified.")
-            @Valid @RequestParam(value = "user_id", required = false) Optional<String> userId) {
-        if (!tenantId.isPresent() && userId.isPresent()) {
-            throw new BadRequestException("userId must be specified with associated tenantId!");
+        /**
+         * POST /api/v1/tenants : Create a tenant in the platform
+         * Operation ID: createTenant&lt;br&gt; Create a tenant in the platform. The
+         * platform decides whether to adopt the cd_tenand_id in request body as
+         * tenant_id. This means the platform could generate new tenant_id by itself for
+         * the new tenant. The tenant_id in request body is ignored.
+         *
+         * @param osisTenant Tenant to create in the platform (required)
+         * @return A tenant is created (status code 201)
+         *         or Bad Request (status code 400)
+         */
+        @ApiOperation(value = "Create a tenant in the platform", nickname = "createTenant", notes = "Operation ID: createTenant<br> Create a tenant in the platform. The platform decides whether to adopt the cd_tenand_id in request body as tenant_id. This means the platform could generate new tenant_id by itself for the new tenant. The tenant_id in request body is ignored. ", response = OsisTenant.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "tenant", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 201, message = "A tenant is created", response = OsisTenant.class),
+                        @ApiResponse(code = 400, message = "Bad Request", response = Error.class) })
+        @ApiImplicitParams({
+        })
+        @PostMapping(value = "/api/v1/tenants", produces = "application/json", consumes = "application/json")
+        public OsisTenant createTenant(
+                        @ApiParam(value = "Tenant to create in the platform", required = true) @Valid @RequestBody OsisTenant osisTenant) {
+                return osisService.createTenant(osisTenant);
         }
-        return osisService.getOsisUsage(tenantId, userId);
-    }
 
+        /**
+         * POST /api/v1/tenants/{tenantId}/users : Create a user in the platform tenant
+         * Operation ID: createUser&lt;br&gt; Create a user in the platform. The
+         * platform decides whether to adopt the cd_user_id in request body as canonical
+         * ID. This means the platform could generate new user_id by itself for the new
+         * user. The user_id in request body is ignored.
+         *
+         * @param tenantId The ID of the tenant which the created user belongs to
+         *                 (required)
+         * @param osisUser User to create in the platform tenant. canonical_user_id is
+         *                 ignored. (required)
+         * @return A user is created (status code 201)
+         *         or Bad Request (status code 400)
+         */
+        @ApiOperation(value = "Create a user in the platform tenant", nickname = "createUser", notes = "Operation ID: createUser<br> Create a user in the platform. The platform decides whether to adopt the cd_user_id in request body as canonical ID. This means the platform could generate new user_id by itself for the new user. The user_id in request body is ignored. ", response = OsisUser.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "user", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 201, message = "A user is created", response = OsisUser.class),
+                        @ApiResponse(code = 400, message = "Bad Request", response = Error.class) })
+        @ApiImplicitParams({
+        })
+        @PostMapping(value = "/api/v1/tenants/{tenantId}/users", produces = "application/json", consumes = "application/json")
+        public OsisUser createUser(
+                        @ApiParam(value = "The ID of the tenant which the created user belongs to", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "User to create in the platform tenant. canonical_user_id is ignored.", required = true) @Valid @RequestBody OsisUser osisUser) {
+                logger.info("create user");
+                osisUser.setTenantId(tenantId);
+                return osisService.createUser(osisUser);
+        }
 
-    /**
-     * GET /api/v1/users/{canonicalUserId} : Get the user with user canonical ID
-     * Operation ID: getUserWithCanonicalID&lt;br&gt; Get the user with the user canonical ID
-     *
-     * @param canonicalUserId The canonical ID of the user to get (required)
-     * @return The user is returned (status code 200)
-     * or The tenant doesn&#39;t exist (status code 404)
-     */
-    @ApiOperation(value = "Get the user with user canonical ID", nickname = "getUserWithCanonicalID", notes = "Operation ID: getUserWithCanonicalID<br> Get the user with the user canonical ID ", response = OsisUser.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"user", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The user is returned", response = OsisUser.class),
-            @ApiResponse(code = 404, message = "The tenant doesn't exist")})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/users/{canonicalUserId}",
-            produces = "application/json")
-    public OsisUser getUserWithCanonicalID(
-            @ApiParam(value = "The canonical ID of the user to get", required = true)
-            @PathVariable("canonicalUserId") String canonicalUserId) {
-        return osisService.getUser(canonicalUserId);
-    }
+        /**
+         * DELETE /api/v1/s3credentials/{accessKey} : Delete the S3 credential of the
+         * platform user
+         * Operation ID: deleteCredential&lt;br&gt; Delete the S3 credential of the
+         * platform user. Parameters tenant_id and tenant_id are always in request; the
+         * platform decides whehter to use them.
+         *
+         * @param tenantId  The ID of the tenant which the user belongs to (required)
+         * @param userId    The ID of the user which the deleted S3 credential belongs
+         *                  to (required)
+         * @param accessKey The access key of the S3 credential to delete (required)
+         * @return The S3 credential is deleted (status code 204)
+         *         or The optional API is not implemented (status code 501)
+         */
+        @ApiOperation(value = "Delete the S3 credential of the platform user", nickname = "deleteCredential", notes = "Operation ID: deleteCredential<br> Delete the S3 credential of the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them. ", authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "s3credential", "optional", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 204, message = "The S3 credential is deleted"),
+                        @ApiResponse(code = 501, message = "The optional API is not implemented") })
+        @ApiImplicitParams({
+        })
+        @DeleteMapping(value = "/api/v1/s3credentials/{accessKey}")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        public void deleteCredential(
+                        @NotNull @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
+                        @NotNull @ApiParam(value = "The ID of the user which the deleted S3 credential belongs to", required = true) @Valid @RequestParam(value = "user_id", required = true) String userId,
+                        @ApiParam(value = "The access key of the S3 credential to delete", required = true) @PathVariable("accessKey") String accessKey) {
+                osisService.deleteS3Credential(tenantId, userId, accessKey);
+        }
 
+        /**
+         * DELETE /api/v1/tenants/{tenantId} : Delete a tenant in the platform
+         * Operation ID: deleteTenant&lt;br&gt; Delete a tenant in the platform
+         *
+         * @param tenantId  Tenant ID of the tenant to delete (required)
+         * @param purgeData Purge data when the tenant is deleted (optional, default to
+         *                  false)
+         * @return The tenant is deleted (status code 204)
+         *         or The optional API is not implemented (status code 501)
+         */
+        @ApiOperation(value = "Delete a tenant in the platform", nickname = "deleteTenant", notes = "Operation ID: deleteTenant<br> Delete a tenant in the platform ", authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "tenant", "optional", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 204, message = "The tenant is deleted"),
+                        @ApiResponse(code = 501, message = "The optional API is not implemented") })
+        @ApiImplicitParams({
+        })
+        @DeleteMapping(value = "/api/v1/tenants/{tenantId}")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        @NotImplement(name = OsisConstants.DELETE_TENANT_API_CODE)
+        public void deleteTenant(
+                        @ApiParam(value = "Tenant ID of the tenant to delete", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "Purge data when the tenant is deleted", defaultValue = "true") @Valid @RequestParam(value = "purge_data", required = false, defaultValue = "true") Boolean purgeData) {
+                osisService.deleteTenant(tenantId, purgeData);
+        }
 
-    /**
-     * GET /api/v1/tenants/{tenantId}/users/{userId} : Get the user with user ID of the tenant
-     * Operation ID: getUserWithId&lt;br&gt; Get the user with the user ID in the tenant. The cd_user_id in the response indicates the mapping between Cloud Direct user and platform user.
-     *
-     * @param tenantId The ID of the tenant which the user belongs to (required)
-     * @param userId   The ID of the user to get (required)
-     * @return The user is returned (status code 200)
-     * or The tenant doesn&#39;t exist (status code 404)
-     */
-    @ApiOperation(value = "Get the user with user ID of the tenant", nickname = "getUserWithId", notes = "Operation ID: getUserWithId<br> Get the user with the user ID in the tenant. The cd_user_id in the response indicates the mapping between Cloud Direct user and platform user. ", response = OsisUser.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"user", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The user is returned", response = OsisUser.class),
-            @ApiResponse(code = 404, message = "The tenant doesn't exist")})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}",
-            produces = "application/json")
-    public OsisUser getUserWithId(
-            @ApiParam(value = "The ID of the tenant which the user belongs to", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "The ID of the user to get", required = true)
-            @PathVariable("userId") String userId) {
-        return osisService.getUser(tenantId, userId);
-    }
+        /**
+         * DELETE /api/v1/tenants/{tenantId}/users/{userId} : Delete the user in the
+         * platform tenant
+         * Operation ID: deleteUser&lt;br&gt; Delete the user in the platform tenant
+         *
+         * @param tenantId  The ID of the tenant which the deleted user belongs to
+         *                  (required)
+         * @param userId    The ID of the user to delete (required)
+         * @param purgeData Purge data when the user is deleted (optional, default to
+         *                  false)
+         * @return The user is deleted (status code 204)
+         */
+        @ApiOperation(value = "Delete the user in the platform tenant", nickname = "deleteUser", notes = "Operation ID: deleteUser<br> Delete the user in the platform tenant ", authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "user", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 204, message = "The user is deleted") })
+        @ApiImplicitParams({
+        })
+        @DeleteMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        public void deleteUser(
+                        @ApiParam(value = "The ID of the tenant which the deleted user belongs to", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "The ID of the user to delete", required = true) @PathVariable("userId") String userId,
+                        @ApiParam(value = "Purge data when the user is deleted", defaultValue = "true") @Valid @RequestParam(value = "purge_data", required = false, defaultValue = "true") Boolean purgeData) {
+                osisService.deleteUser(tenantId, userId, purgeData);
+        }
 
+        /**
+         * GET /api/v1/bucket-list : Get the bucket list of the platform tenant
+         * Operation ID: getBucketList&lt;br&gt; Get the bucket list of the platform
+         * tenant
+         *
+         * @param tenantId The ID of the tenant to get its bueckt list (required)
+         * @param offset   The start index of buckets to return (optional)
+         * @param limit    The maximum number of buckets to return (optional)
+         * @return The bucket list of the platform tenant is returned (status code 200)
+         *         or The optional API is not implemented (status code 501)
+         */
+        @ApiOperation(value = "Get the bucket list of the platform tenant", nickname = "getBucketList", notes = "Operation ID: getBucketList<br> Get the bucket list of the platform tenant ", response = OsisBucketMeta.class, responseContainer = "List", authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "bucketlist", "optional", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The bucket list of the platform tenant is returned", response = OsisBucketMeta.class, responseContainer = "List"),
+                        @ApiResponse(code = 501, message = "The optional API is not implemented") })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/bucket-list", produces = "application/json")
+        @NotImplement(name = OsisConstants.GET_BUCKET_LIST_API_CODE)
+        public PageOfOsisBucketMeta getBucketList(
+                        @NotNull @ApiParam(value = "The ID of the tenant to get its bueckt list", required = true) @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
+                        @ApiParam(value = "The start index of buckets to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
+                        @ApiParam(value = "The maximum number of buckets to return") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit) {
+                return osisService.getBucketList(tenantId, offset, limit);
+        }
 
-    /**
-     * HEAD /api/v1/tenants/{tenantId} : Check whether the tenant exists
-     * Operation ID: headTenant&lt;br&gt; Check whether the tenant exists
-     *
-     * @param tenantId Tenant ID to check on the platform (required)
-     * @return The tenant exists (status code 200)
-     * or The tenant doesn&#39;t exist (status code 404)
-     */
-    @ApiOperation(value = "Check whether the tenant exists", nickname = "headTenant", notes = "Operation ID: headTenant<br> Check whether the tenant exists ", authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"tenant", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The tenant exists"),
-            @ApiResponse(code = 404, message = "The tenant doesn't exist")})
-    @ApiImplicitParams({
-    })
-    @RequestMapping(value = "/api/v1/tenants/{tenantId}",
-            method = RequestMethod.HEAD)
-    public Void headTenant(
-            @ApiParam(value = "Tenant ID to check on the platform", required = true)
-            @PathVariable("tenantId") String tenantId) {
-        osisService.headTenant(tenantId);
-        return null;
-    }
+        /**
+         * GET /api/v1/console : Get the console URI of the platform or platform tenant
+         * Operation ID: getConsole&lt;br&gt; Get the console URI of the platform or
+         * platform tenant if tenantId is specified
+         *
+         * @param tenantId The ID of the tenant to get its console URI (optional)
+         * @return The console URI is returned (status code 200)
+         *         or The optional API is not implemented (status code 501)
+         */
+        @ApiOperation(value = "Get the console URI of the platform or platform tenant", nickname = "getConsole", notes = "Operation ID: getConsole<br> Get the console URI of the platform or platform tenant if tenantId is specified ", response = String.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "console", "optional", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The console URI is returned", response = String.class),
+                        @ApiResponse(code = 501, message = "The optional API is not implemented") })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/console", produces = "application/json")
+        public String getConsole(
+                        @ApiParam(value = "The ID of the tenant to get its console URI") @Valid @RequestParam(value = "tenant_id", required = false) Optional<String> tenantId) {
+                if (tenantId.isPresent()) {
+                        return osisService.getTenantConsoleUrl(tenantId.get());
+                } else {
+                        return osisService.getProviderConsoleUrl();
+                }
+        }
 
+        /**
+         * GET /api/v1/s3credentials/{accessKey} : Get S3 credential of the platform
+         * user
+         * Operation ID: createCredential&lt;br&gt; Get S3 credential of the platform
+         * user. Parameters tenant_id and tenant_id are always in request; the platform
+         * decides whehter to use them.
+         *
+         * @param tenantId  The ID of the tenant which the user belongs to (required)
+         * @param userId    The ID of the user which the S3 credential belongs to
+         *                  (required)
+         * @param accessKey The access key of the S3 credential to get (required)
+         * @return The S3 credenital is returned (status code 200)
+         *         or Not Found (status code 404)
+         */
+        @ApiOperation(value = "Get S3 credential of the platform user", nickname = "getCredential", notes = "Operation ID: createCredential<br> Get S3 credential of the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them. ", response = OsisS3Credential.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "s3credential", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The S3 credenital is returned", response = OsisS3Credential.class),
+                        @ApiResponse(code = 404, message = "Not Found", response = Object.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/s3credentials/{accessKey}", produces = "application/json")
+        public OsisS3Credential getCredential(
+                        @NotNull @ApiParam(value = "The ID of the tenant which the user belongs to", required = false) @Valid @RequestParam(value = "tenant_id", required = false) Optional<String> tenantId,
+                        @NotNull @ApiParam(value = "The ID of the user which the S3 credential belongs to", required = false) @Valid @RequestParam(value = "user_id", required = false) Optional<String> userId,
+                        @ApiParam(value = "The access key of the S3 credential to get", required = true) @PathVariable("accessKey") String accessKey) {
+                return osisService.getS3Credential(tenantId.orElse(""), userId.orElse(""), accessKey);
+        }
 
-    /**
-     * HEAD /api/v1/tenants/{tenantId}/users/{userId} : Check whether the user exists
-     * Operation ID: headUser&lt;br&gt; Check whether the user exists in the platform tenant
-     *
-     * @param tenantId The ID of the tenant which the user belongs to (required)
-     * @param userId   The ID of the user to check (required)
-     * @return The user exists (status code 200)
-     * or The user doesn&#39;t exist (status code 404)
-     * or The optional API is not implemented (status code 501)
-     */
-    @ApiOperation(value = "Check whether the user exists", nickname = "headUser", notes = "Operation ID: headUser<br> Check whether the user exists in the platform tenant ", authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"user", "optional",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The user exists"),
-            @ApiResponse(code = 404, message = "The user doesn't exist"),
-            @ApiResponse(code = 501, message = "The optional API is not implemented")})
-    @ApiImplicitParams({
-    })
-    @RequestMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}",
-            method = RequestMethod.HEAD)
-    @NotImplement(name = OsisConstants.HEAD_USER_API_CODE)
-    public void headUser(
-            @ApiParam(value = "The ID of the tenant which the user belongs to", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "The ID of the user to check", required = true)
-            @PathVariable("userId") String userId) {
-        osisService.headUser(tenantId, userId);
+        /**
+         * GET /api/info : Get the REST servcies information
+         * Operation ID: getInfo&lt;br&gt; &#39;Get the information of the REST
+         * Services, including platform name, OSIS version and etc&#39;
+         *
+         * @return OK (status code 200)
+         */
+        @ApiOperation(value = "Get the REST servcies information", nickname = "getInfo", notes = "Operation ID: getInfo<br> 'Get the information of the REST Services, including platform name, OSIS version and etc' ", response = Information.class, tags = {
+                        "info", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "OK", response = Information.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/info", produces = "application/json")
+        @ResponseStatus(HttpStatus.OK)
+        public Information getInfo(HttpServletRequest request) {
+                StringBuffer url = request.getRequestURL();
+                String domain = url.substring(0, url.lastIndexOf(request.getRequestURI()));
+                logger.info(domain);
+                return osisService.getInformation(domain);
+        }
 
-    }
+        /**
+         * GET /api/v1/s3capabilities : Get S3 capabilities of the platform
+         * Operation ID: getS3Capabilities&lt;br&gt; Get S3 capabilities of the platform
+         *
+         * @return S3 capabilities of the platform (status code 200)
+         */
+        @ApiOperation(value = "Get S3 capabilities of the platform", nickname = "getS3Capabilities", notes = "Operation ID: getS3Capabilities<br> Get S3 capabilities of the platform ", response = OsisS3Capabilities.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "usage", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "S3 capabilities of the platform", response = OsisS3Capabilities.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/s3capabilities", produces = "application/json")
+        public OsisS3Capabilities getS3Capabilities() {
+                return osisService.getS3Capabilities();
+        }
 
+        /**
+         * GET /api/v1/tenants/{tenantId} : Get the tenant
+         * Operation ID: getTenant&lt;br&gt; Get the tenant with tenant ID. The
+         * cd_tenant_id in the response indicates the mapping between Cloud Direct
+         * tenant and platform tenant. \&quot;
+         *
+         * @param tenantId Tenant ID to get the tenant from the platform (required)
+         * @return The tenant is returned (status code 200)
+         *         or The tenant doesn&#39;t exist (status code 404)
+         *         or The optional API is not implemented (status code 501)
+         */
+        @ApiOperation(value = "Get the tenant", nickname = "getTenant", notes = "Operation ID: getTenant<br> Get the tenant with tenant ID. The cd_tenant_id in the response indicates the mapping between Cloud Direct tenant and platform tenant. \" ", response = OsisTenant.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "tenant", "optional", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The tenant is returned", response = OsisTenant.class),
+                        @ApiResponse(code = 404, message = "The tenant doesn't exist"),
+                        @ApiResponse(code = 501, message = "The optional API is not implemented") })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/tenants/{tenantId}", produces = "application/json")
+        @NotImplement(name = OsisConstants.GET_TENANT_API_CODE)
+        public OsisTenant getTenant(
+                        @ApiParam(value = "Tenant ID to get the tenant from the platform", required = true) @PathVariable("tenantId") String tenantId) {
+                return osisService.getTenant(tenantId);
+        }
 
-    /**
-     * GET /api/v1/tenants/{tenantId}/users/{userId}/s3credentials : List S3 credentials of the platform user
-     * Operation ID: listCredentials&lt;br&gt; List S3 credentials of the platform user
-     *
-     * @param tenantId The ID of the tenant which the user belongs to (required)
-     * @param userId   The ID of user which the S3 credenitials belong to (required)
-     * @param offset   The start index of credentials to return (optional)
-     * @param limit    Maximum number of credentials to return (optional)
-     * @return S3 credentials of the platform user are returned (status code 200)
-     */
-    @ApiOperation(value = "List S3 credentials of the platform user", nickname = "listCredentials", notes = "Operation ID: listCredentials<br> List S3 credentials of the platform user ", response = PageOfS3Credentials.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"s3credential", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "S3 credentials of the platform user are returned", response = PageOfS3Credentials.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}/s3credentials",
-            produces = "application/json")
-    public PageOfS3Credentials listCredentials(
-            @ApiParam(value = "The ID of the tenant which the user belongs to", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "The ID of user which the S3 credenitials belong to", required = true)
-            @PathVariable("userId") String userId,
-            @ApiParam(value = "The start index of credentials to return")
-            @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") Long offset,
-            @ApiParam(value = "Maximum number of credentials to return")
-            @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Long limit) {
+        /**
+         * GET /api/v1/usage : Get the usage of the platform tenant or user
+         * Operation ID: getUsage&lt;br&gt; Get the platform usage of global (without
+         * query parameter), tenant (with tenant_id) or user (only with user_id).
+         *
+         * @param tenantId The ID of the tenant to get its usage. &#39;tenant_id&#39;
+         *                 takes precedence over &#39;user_id&#39; to take effect if
+         *                 both are specified. (optional)
+         * @param userId   The ID of the user to get its usage. &#39;tenant_id&#39;
+         *                 takes precedence over &#39;user_id&#39; to take effect if
+         *                 both are specified. (optional)
+         * @return The usage of the tenant or user is returned (status code 200)
+         *         or The optional API is not implemented (status code 501)
+         */
+        @ApiOperation(value = "Get the usage of the platform tenant or user", nickname = "getUsage", notes = "Operation ID: getUsage<br> Get the platform usage of global (without query parameter), tenant (with tenant_id) or user (only with user_id). ", response = OsisUsage.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "usage", "optional", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The usage of the tenant or user is returned", response = OsisUsage.class),
+                        @ApiResponse(code = 501, message = "The optional API is not implemented") })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/usage", produces = "application/json")
+        public OsisUsage getUsage(
+                        @ApiParam(value = "The ID of the tenant to get its usage. 'tenant_id' takes precedence over 'user_id' to take effect if both are specified.") @Valid @RequestParam(value = "tenant_id", required = false) Optional<String> tenantId,
+                        @ApiParam(value = "The ID of the user to get its usage. 'tenant_id' takes precedence over 'user_id' to take effect if both are specified.") @Valid @RequestParam(value = "user_id", required = false) Optional<String> userId) {
+                if (!tenantId.isPresent() && userId.isPresent()) {
+                        throw new BadRequestException("userId must be specified with associated tenantId!");
+                }
+                return osisService.getOsisUsage(tenantId, userId);
+        }
 
+        /**
+         * GET /api/v1/users/{canonicalUserId} : Get the user with user canonical ID
+         * Operation ID: getUserWithCanonicalID&lt;br&gt; Get the user with the user
+         * canonical ID
+         *
+         * @param canonicalUserId The canonical ID of the user to get (required)
+         * @return The user is returned (status code 200)
+         *         or The tenant doesn&#39;t exist (status code 404)
+         */
+        @ApiOperation(value = "Get the user with user canonical ID", nickname = "getUserWithCanonicalID", notes = "Operation ID: getUserWithCanonicalID<br> Get the user with the user canonical ID ", response = OsisUser.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "user", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The user is returned", response = OsisUser.class),
+                        @ApiResponse(code = 404, message = "The tenant doesn't exist") })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/users/{canonicalUserId}", produces = "application/json")
+        public OsisUser getUserWithCanonicalID(
+                        @ApiParam(value = "The canonical ID of the user to get", required = true) @PathVariable("canonicalUserId") String canonicalUserId) {
+                return osisService.getUser(canonicalUserId);
+        }
 
-        return osisService.listS3Credentials(tenantId, userId, offset, limit);
+        /**
+         * GET /api/v1/tenants/{tenantId}/users/{userId} : Get the user with user ID of
+         * the tenant
+         * Operation ID: getUserWithId&lt;br&gt; Get the user with the user ID in the
+         * tenant. The cd_user_id in the response indicates the mapping between Cloud
+         * Direct user and platform user.
+         *
+         * @param tenantId The ID of the tenant which the user belongs to (required)
+         * @param userId   The ID of the user to get (required)
+         * @return The user is returned (status code 200)
+         *         or The tenant doesn&#39;t exist (status code 404)
+         */
+        @ApiOperation(value = "Get the user with user ID of the tenant", nickname = "getUserWithId", notes = "Operation ID: getUserWithId<br> Get the user with the user ID in the tenant. The cd_user_id in the response indicates the mapping between Cloud Direct user and platform user. ", response = OsisUser.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "user", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The user is returned", response = OsisUser.class),
+                        @ApiResponse(code = 404, message = "The tenant doesn't exist") })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}", produces = "application/json")
+        public OsisUser getUserWithId(
+                        @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "The ID of the user to get", required = true) @PathVariable("userId") String userId) {
+                return osisService.getUser(tenantId, userId);
+        }
 
-    }
+        /**
+         * HEAD /api/v1/tenants/{tenantId} : Check whether the tenant exists
+         * Operation ID: headTenant&lt;br&gt; Check whether the tenant exists
+         *
+         * @param tenantId Tenant ID to check on the platform (required)
+         * @return The tenant exists (status code 200)
+         *         or The tenant doesn&#39;t exist (status code 404)
+         */
+        @ApiOperation(value = "Check whether the tenant exists", nickname = "headTenant", notes = "Operation ID: headTenant<br> Check whether the tenant exists ", authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "tenant", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The tenant exists"),
+                        @ApiResponse(code = 404, message = "The tenant doesn't exist") })
+        @ApiImplicitParams({
+        })
+        @RequestMapping(value = "/api/v1/tenants/{tenantId}", method = RequestMethod.HEAD)
+        public Void headTenant(
+                        @ApiParam(value = "Tenant ID to check on the platform", required = true) @PathVariable("tenantId") String tenantId) {
+                osisService.headTenant(tenantId);
+                return null;
+        }
 
+        /**
+         * HEAD /api/v1/tenants/{tenantId}/users/{userId} : Check whether the user
+         * exists
+         * Operation ID: headUser&lt;br&gt; Check whether the user exists in the
+         * platform tenant
+         *
+         * @param tenantId The ID of the tenant which the user belongs to (required)
+         * @param userId   The ID of the user to check (required)
+         * @return The user exists (status code 200)
+         *         or The user doesn&#39;t exist (status code 404)
+         *         or The optional API is not implemented (status code 501)
+         */
+        @ApiOperation(value = "Check whether the user exists", nickname = "headUser", notes = "Operation ID: headUser<br> Check whether the user exists in the platform tenant ", authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "user", "optional", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The user exists"),
+                        @ApiResponse(code = 404, message = "The user doesn't exist"),
+                        @ApiResponse(code = 501, message = "The optional API is not implemented") })
+        @ApiImplicitParams({
+        })
+        @RequestMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}", method = RequestMethod.HEAD)
+        @NotImplement(name = OsisConstants.HEAD_USER_API_CODE)
+        public void headUser(
+                        @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "The ID of the user to check", required = true) @PathVariable("userId") String userId) {
+                osisService.headUser(tenantId, userId);
 
-    /**
-     * GET /api/v1/tenants : List tenants of platform
-     * Operation ID: listTenants&lt;br&gt; List tenants of the platform
-     *
-     * @param offset The start index of tenants to return (optional)
-     * @param limit  Maximum number of tenants to return (optional)
-     * @return Tenants of the platform are returned (status code 200)
-     */
-    @ApiOperation(value = "List tenants of platform", nickname = "listTenants", notes = "Operation ID: listTenants<br> List tenants of the platform ", response = PageOfTenants.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"tenant", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Tenants of the platform are returned", response = PageOfTenants.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/tenants",
-            produces = "application/json")
-    public PageOfTenants listTenants(
-            @ApiParam(value = "The start index of tenants to return")
-            @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") Long offset,
-            @ApiParam(value = "Maximum number of tenants to return")
-            @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Long limit) {
-        return osisService.listTenants(offset, limit);
-    }
+        }
 
+        /**
+         * GET /api/v1/tenants/{tenantId}/users/{userId}/s3credentials : List S3
+         * credentials of the platform user
+         * Operation ID: listCredentials&lt;br&gt; List S3 credentials of the platform
+         * user
+         *
+         * @param tenantId The ID of the tenant which the user belongs to (required)
+         * @param userId   The ID of user which the S3 credenitials belong to (required)
+         * @param offset   The start index of credentials to return (optional)
+         * @param limit    Maximum number of credentials to return (optional)
+         * @return S3 credentials of the platform user are returned (status code 200)
+         */
+        @ApiOperation(value = "List S3 credentials of the platform user", nickname = "listCredentials", notes = "Operation ID: listCredentials<br> List S3 credentials of the platform user ", response = PageOfS3Credentials.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "s3credential", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "S3 credentials of the platform user are returned", response = PageOfS3Credentials.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}/s3credentials", produces = "application/json")
+        public PageOfS3Credentials listCredentials(
+                        @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "The ID of user which the S3 credenitials belong to", required = true) @PathVariable("userId") String userId,
+                        @ApiParam(value = "The start index of credentials to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") Long offset,
+                        @ApiParam(value = "Maximum number of credentials to return") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Long limit) {
 
-    /**
-     * GET /api/v1/tenants/{tenantId}/users : List users of the platform tenant
-     * Operation ID: listUsers&lt;br&gt; List users of the platform tenant
-     *
-     * @param tenantId The ID of the tenant which the listed users belongs to (required)
-     * @param offset   The start index of users to return (optional)
-     * @param limit    Maximum number of users to return (optional)
-     * @return Users of the platform tenant are returned (status code 200)
-     */
-    @ApiOperation(value = "List users of the platform tenant", nickname = "listUsers", notes = "Operation ID: listUsers<br> List users of the platform tenant ", response = PageOfUsers.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"user", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Users of the platform tenant are returned", response = PageOfUsers.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/tenants/{tenantId}/users",
-            produces = "application/json")
-    public PageOfUsers listUsers(
-            @ApiParam(value = "The ID of the tenant which the listed users belongs to", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "The start index of users to return")
-            @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
-            @ApiParam(value = "Maximum number of users to return")
-            @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit) {
-        return osisService.listUsers(tenantId, offset, limit);
-    }
+                return osisService.listS3Credentials(tenantId, userId, offset, limit);
 
+        }
 
-    /**
-     * PATCH /api/v1/s3credentials/{accessKey} : Enable or disable S3 credential for the platform user
-     * Operation ID: updateCredentialStatus&lt;br&gt; Enabled or disable S3 credential for the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them.
-     *
-     * @param tenantId         The ID of the tenant which the user belongs to (required)
-     * @param userId           The ID of the user which the status updated S3 credential belongs to (required)
-     * @param accessKey        The access key of the S3 credential to update status (required)
-     * @param osisS3Credential The S3 credential containing the status to update. Only property &#39;active&#39; takes effect (required)
-     * @return The status of the S3 credential is updated (status code 200)
-     * or Bad Request (status code 400)
-     * or The optional API is not implemented (status code 501)
-     */
-    @ApiOperation(value = "Enable or disable S3 credential for the platform user", nickname = "updateCredentialStatus", notes = "Operation ID: updateCredentialStatus<br> Enabled or disable S3 credential for the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them. ", response = OsisS3Credential.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"s3credential", "optional",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The status of the S3 credential is updated", response = OsisS3Credential.class),
-            @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
-            @ApiResponse(code = 501, message = "The optional API is not implemented")})
-    @ApiImplicitParams({
-    })
-    @PatchMapping(value = "/api/v1/s3credentials/{accessKey}",
-            produces = "application/json",
-            consumes = "application/json")
-    @NotImplement(name = OsisConstants.UPDATE_CREDENTIAL_STATUS_API_CODE)
-    public OsisS3Credential updateCredentialStatus(
-            @NotNull @ApiParam(value = "The ID of the tenant which the user belongs to", required = true)
-            @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
-            @NotNull @ApiParam(value = "The ID of the user which the status updated S3 credential belongs to", required = true)
-            @Valid @RequestParam(value = "user_id", required = true) String userId,
-            @ApiParam(value = "The access key of the S3 credential to update status", required = true)
-            @PathVariable("accessKey") String accessKey,
-            @ApiParam(value = "The S3 credential containing the status to update. Only property 'active' takes effect", required = true)
-            @Valid @RequestBody OsisS3Credential osisS3Credential) {
-        throw new NotImplementedException();
-    }
+        /**
+         * GET /api/v1/tenants : List tenants of platform
+         * Operation ID: listTenants&lt;br&gt; List tenants of the platform
+         *
+         * @param offset The start index of tenants to return (optional)
+         * @param limit  Maximum number of tenants to return (optional)
+         * @return Tenants of the platform are returned (status code 200)
+         */
+        @ApiOperation(value = "List tenants of platform", nickname = "listTenants", notes = "Operation ID: listTenants<br> List tenants of the platform ", response = PageOfTenants.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "tenant", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "Tenants of the platform are returned", response = PageOfTenants.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/tenants", produces = "application/json")
+        public PageOfTenants listTenants(
+                        @ApiParam(value = "The start index of tenants to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") Long offset,
+                        @ApiParam(value = "Maximum number of tenants to return") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") Long limit) {
+                return osisService.listTenants(offset, limit);
+        }
 
+        /**
+         * GET /api/v1/tenants/{tenantId}/users : List users of the platform tenant
+         * Operation ID: listUsers&lt;br&gt; List users of the platform tenant
+         *
+         * @param tenantId The ID of the tenant which the listed users belongs to
+         *                 (required)
+         * @param offset   The start index of users to return (optional)
+         * @param limit    Maximum number of users to return (optional)
+         * @return Users of the platform tenant are returned (status code 200)
+         */
+        @ApiOperation(value = "List users of the platform tenant", nickname = "listUsers", notes = "Operation ID: listUsers<br> List users of the platform tenant ", response = PageOfUsers.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "user", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "Users of the platform tenant are returned", response = PageOfUsers.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/tenants/{tenantId}/users", produces = "application/json")
+        public PageOfUsers listUsers(
+                        @ApiParam(value = "The ID of the tenant which the listed users belongs to", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "The start index of users to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
+                        @ApiParam(value = "Maximum number of users to return") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit) {
+                return osisService.listUsers(tenantId, offset, limit);
+        }
 
-    /**
-     * PATCH /api/v1/tenants/{tenantId} : Enable or disable tenant of the platform
-     * Operation ID: updateTenantStatus&lt;br&gt; Update status of the tenant in the platform
-     *
-     * @param tenantId   Tenant ID of the tenant to update status (required)
-     * @param osisTenant Tenant status to update in the platform. Only property &#39;active&#39; takes effect (required)
-     * @return The tenant status is updated (status code 200)
-     * or Bad Request (status code 400)
-     */
-    @ApiOperation(value = "Enable or disable tenant of the platform", nickname = "updateTenantStatus", notes = "Operation ID: updateTenantStatus<br> Update status of the tenant in the platform ", response = OsisTenant.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"tenant", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The tenant status is updated", response = OsisTenant.class),
-            @ApiResponse(code = 400, message = "Bad Request", response = Error.class)})
-    @ApiImplicitParams({
-    })
-    @PatchMapping(value = "/api/v1/tenants/{tenantId}",
-            produces = "application/json",
-            consumes = "application/json")
-    public OsisTenant updateTenantStatus(
-            @ApiParam(value = "Tenant ID of the tenant to update status", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "Tenant status to update in the platform. Only property 'active' takes effect", required = true)
-            @Valid @RequestBody OsisTenant osisTenant) {
-        return osisService.updateTenant(tenantId, osisTenant);
-    }
+        /**
+         * PATCH /api/v1/s3credentials/{accessKey} : Enable or disable S3 credential for
+         * the platform user
+         * Operation ID: updateCredentialStatus&lt;br&gt; Enabled or disable S3
+         * credential for the platform user. Parameters tenant_id and tenant_id are
+         * always in request; the platform decides whehter to use them.
+         *
+         * @param tenantId         The ID of the tenant which the user belongs to
+         *                         (required)
+         * @param userId           The ID of the user which the status updated S3
+         *                         credential belongs to (required)
+         * @param accessKey        The access key of the S3 credential to update status
+         *                         (required)
+         * @param osisS3Credential The S3 credential containing the status to update.
+         *                         Only property &#39;active&#39; takes effect
+         *                         (required)
+         * @return The status of the S3 credential is updated (status code 200)
+         *         or Bad Request (status code 400)
+         *         or The optional API is not implemented (status code 501)
+         */
+        @ApiOperation(value = "Enable or disable S3 credential for the platform user", nickname = "updateCredentialStatus", notes = "Operation ID: updateCredentialStatus<br> Enabled or disable S3 credential for the platform user. Parameters tenant_id and tenant_id are always in request; the platform decides whehter to use them. ", response = OsisS3Credential.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "s3credential", "optional", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The status of the S3 credential is updated", response = OsisS3Credential.class),
+                        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+                        @ApiResponse(code = 501, message = "The optional API is not implemented") })
+        @ApiImplicitParams({
+        })
+        @PatchMapping(value = "/api/v1/s3credentials/{accessKey}", produces = "application/json", consumes = "application/json")
+        @NotImplement(name = OsisConstants.UPDATE_CREDENTIAL_STATUS_API_CODE)
+        public OsisS3Credential updateCredentialStatus(
+                        @NotNull @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
+                        @NotNull @ApiParam(value = "The ID of the user which the status updated S3 credential belongs to", required = true) @Valid @RequestParam(value = "user_id", required = true) String userId,
+                        @ApiParam(value = "The access key of the S3 credential to update status", required = true) @PathVariable("accessKey") String accessKey,
+                        @ApiParam(value = "The S3 credential containing the status to update. Only property 'active' takes effect", required = true) @Valid @RequestBody OsisS3Credential osisS3Credential) {
+                throw new NotImplementedException();
+        }
 
+        /**
+         * PATCH /api/v1/tenants/{tenantId} : Enable or disable tenant of the platform
+         * Operation ID: updateTenantStatus&lt;br&gt; Update status of the tenant in the
+         * platform
+         *
+         * @param tenantId   Tenant ID of the tenant to update status (required)
+         * @param osisTenant Tenant status to update in the platform. Only property
+         *                   &#39;active&#39; takes effect (required)
+         * @return The tenant status is updated (status code 200)
+         *         or Bad Request (status code 400)
+         */
+        @ApiOperation(value = "Enable or disable tenant of the platform", nickname = "updateTenantStatus", notes = "Operation ID: updateTenantStatus<br> Update status of the tenant in the platform ", response = OsisTenant.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "tenant", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "The tenant status is updated", response = OsisTenant.class),
+                        @ApiResponse(code = 400, message = "Bad Request", response = Error.class) })
+        @ApiImplicitParams({
+        })
+        @PatchMapping(value = "/api/v1/tenants/{tenantId}", produces = "application/json", consumes = "application/json")
+        public OsisTenant updateTenantStatus(
+                        @ApiParam(value = "Tenant ID of the tenant to update status", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "Tenant status to update in the platform. Only property 'active' takes effect", required = true) @Valid @RequestBody OsisTenant osisTenant) {
+                return osisService.updateTenant(tenantId, osisTenant);
+        }
 
-    /**
-     * PATCH /api/v1/tenants/{tenantId}/users/{userId} : Enable or disable status in the tenant
-     * Operation ID: updateUserStatus&lt;br&gt; Update status of the user in the platform tenant
-     *
-     * @param tenantId The ID of the tenant which the user to update belongs to (required)
-     * @param userId   The ID of the user to update (required)
-     * @param osisUser User status to update in the platform tenant. Only property &#39;active&#39; takes effect (required)
-     * @return The user status is updated (status code 201)
-     * or Bad Request (status code 400)
-     */
-    @ApiOperation(value = "Enable or disable status in the tenant", nickname = "updateUserStatus", notes = "Operation ID: updateUserStatus<br> Update status of the user in the platform tenant ", response = OsisUser.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"user", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "The user status is updated", response = OsisUser.class),
-            @ApiResponse(code = 400, message = "Bad Request", response = Error.class)})
-    @ApiImplicitParams({
-    })
-    @PatchMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}",
-            produces = "application/json",
-            consumes = "application/json")
-    public OsisUser updateUserStatus(
-            @ApiParam(value = "The ID of the tenant which the user to update belongs to", required = true)
-            @PathVariable("tenantId") String tenantId,
-            @ApiParam(value = "The ID of the user to update", required = true)
-            @PathVariable("userId") String userId,
-            @ApiParam(value = "User status to update in the platform tenant. Only property 'active' takes effect", required = true)
-            @Validated(value = Update.class) @RequestBody OsisUser osisUser) {
-        return osisService.updateUser(tenantId, userId, osisUser);
-    }
+        /**
+         * PATCH /api/v1/tenants/{tenantId}/users/{userId} : Enable or disable status in
+         * the tenant
+         * Operation ID: updateUserStatus&lt;br&gt; Update status of the user in the
+         * platform tenant
+         *
+         * @param tenantId The ID of the tenant which the user to update belongs to
+         *                 (required)
+         * @param userId   The ID of the user to update (required)
+         * @param osisUser User status to update in the platform tenant. Only property
+         *                 &#39;active&#39; takes effect (required)
+         * @return The user status is updated (status code 201)
+         *         or Bad Request (status code 400)
+         */
+        @ApiOperation(value = "Enable or disable status in the tenant", nickname = "updateUserStatus", notes = "Operation ID: updateUserStatus<br> Update status of the user in the platform tenant ", response = OsisUser.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "user", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 201, message = "The user status is updated", response = OsisUser.class),
+                        @ApiResponse(code = 400, message = "Bad Request", response = Error.class) })
+        @ApiImplicitParams({
+        })
+        @PatchMapping(value = "/api/v1/tenants/{tenantId}/users/{userId}", produces = "application/json", consumes = "application/json")
+        public OsisUser updateUserStatus(
+                        @ApiParam(value = "The ID of the tenant which the user to update belongs to", required = true) @PathVariable("tenantId") String tenantId,
+                        @ApiParam(value = "The ID of the user to update", required = true) @PathVariable("userId") String userId,
+                        @ApiParam(value = "User status to update in the platform tenant. Only property 'active' takes effect", required = true) @Validated(value = Update.class) @RequestBody OsisUser osisUser) {
+                return osisService.updateUser(tenantId, userId, osisUser);
+        }
 
-    /**
-     * GET /api/v1/tenants/query : Query tenants of platform
-     * Operation ID: queryTenants&lt;br&gt; Query tenants of the platform
-     *
-     * @param offset The start index of tenants to return (optional)
-     * @param limit  Maximum number of tenants to return (optional)
-     * @param filter The conditions to query platform tenants (optional)
-     * @return Tenants of the platform are returned (status code 200)
-     */
-    @ApiOperation(value = "Query tenants of platform", nickname = "queryTenants", notes = "Operation ID: queryTenants<br> Query tenants of the platform ", response = PageOfTenants.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"tenant", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Tenants of the platform are returned", response = PageOfTenants.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/tenants/query",
-            produces = "application/json")
-    public PageOfTenants queryTenants(
-            @ApiParam(value = "The start index of tenants to return")
-            @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
-            @ApiParam(value = "Maximum number of tenants to return")
-            @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit,
-            @ApiParam(value = "The conditions to query platform tenants")
-            @Valid @RequestParam(value = "filter", required = false) String filter) {
-        return osisService.queryTenants(offset, limit, filter);
-    }
+        /**
+         * GET /api/v1/tenants/query : Query tenants of platform
+         * Operation ID: queryTenants&lt;br&gt; Query tenants of the platform
+         *
+         * @param offset The start index of tenants to return (optional)
+         * @param limit  Maximum number of tenants to return (optional)
+         * @param filter The conditions to query platform tenants (optional)
+         * @return Tenants of the platform are returned (status code 200)
+         */
+        @ApiOperation(value = "Query tenants of platform", nickname = "queryTenants", notes = "Operation ID: queryTenants<br> Query tenants of the platform ", response = PageOfTenants.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "tenant", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "Tenants of the platform are returned", response = PageOfTenants.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/tenants/query", produces = "application/json")
+        public PageOfTenants queryTenants(
+                        @ApiParam(value = "The start index of tenants to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
+                        @ApiParam(value = "Maximum number of tenants to return") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit,
+                        @ApiParam(value = "The conditions to query platform tenants") @Valid @RequestParam(value = "filter", required = false) String filter) {
+                return osisService.queryTenants(offset, limit, filter);
+        }
 
+        /**
+         * GET /api/v1/users/query : Query users of the platform tenant
+         * Operation ID: queryUsers&lt;br&gt; Query users of the platform tenant
+         *
+         * @param offset The start index of users to return (optional)
+         * @param limit  Maximum number of users to return (optional)
+         * @param filter The conditions to query platform users (optional)
+         * @return Users of the platform tenant are returned (status code 200)
+         */
+        @ApiOperation(value = "Query users of the platform tenant", nickname = "queryUsers", notes = "Operation ID: queryUsers<br> Query users of the platform tenant ", response = PageOfUsers.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "user", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "Users of the platform tenant are returned", response = PageOfUsers.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/users/query", produces = "application/json")
+        public PageOfUsers queryUsers(
+                        @ApiParam(value = "The start index of users to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
+                        @ApiParam(value = "Maximum number of users to return") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit,
+                        @ApiParam(value = "The conditions to query platform users") @Valid @RequestParam(value = "filter", required = false) String filter) {
 
-    /**
-     * GET /api/v1/users/query : Query users of the platform tenant
-     * Operation ID: queryUsers&lt;br&gt; Query users of the platform tenant
-     *
-     * @param offset The start index of users to return (optional)
-     * @param limit  Maximum number of users to return (optional)
-     * @param filter The conditions to query platform users (optional)
-     * @return Users of the platform tenant are returned (status code 200)
-     */
-    @ApiOperation(value = "Query users of the platform tenant", nickname = "queryUsers", notes = "Operation ID: queryUsers<br> Query users of the platform tenant ", response = PageOfUsers.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"user", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Users of the platform tenant are returned", response = PageOfUsers.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/users/query",
-            produces = "application/json")
-    public PageOfUsers queryUsers(
-            @ApiParam(value = "The start index of users to return")
-            @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
-            @ApiParam(value = "Maximum number of users to return")
-            @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit,
-            @ApiParam(value = "The conditions to query platform users")
-            @Valid @RequestParam(value = "filter", required = false) String filter) {
+                return osisService.queryUsers(offset, limit, filter);
+        }
 
-        return osisService.queryUsers(offset, limit, filter);
-    }
+        /**
+         * GET /api/v1/s3credentials/query : Query S3 credentials of the platform user
+         * Operation ID: queryCredentials&lt;br&gt; Query S3 credentials of the platform
+         * user
+         *
+         * @param offset The start index of credentials to return (optional)
+         * @param limit  Maximum number of credentials to return (optional)
+         * @param filter The conditions to query platform users (optional)
+         * @return S3 credentials of the platform user are returned (status code 200)
+         */
+        @ApiOperation(value = "Query S3 credentials of the platform user", nickname = "queryCredentials", notes = "Operation ID: queryCredentials<br> Query S3 credentials of the platform user ", response = PageOfS3Credentials.class, authorizations = {
+                        @Authorization(value = "basicAuth")
+        }, tags = { "s3credential", "required", })
+        @ApiResponses(value = {
+                        @ApiResponse(code = 200, message = "S3 credentials of the platform user are returned", response = PageOfS3Credentials.class) })
+        @ApiImplicitParams({
+        })
+        @GetMapping(value = "/api/v1/s3credentials/query", produces = "application/json")
+        public PageOfS3Credentials queryCredentials(
+                        @ApiParam(value = "The start index of credentials to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
+                        @ApiParam(value = "Maximum number of credentials to return") @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit,
+                        @ApiParam(value = "The conditions to query platform users") @Valid @RequestParam(value = "filter", required = false) String filter) {
+                return this.osisService.queryS3Credentials(offset, limit, filter);
+        }
 
-    /**
-     * GET /api/v1/s3credentials/query : Query S3 credentials of the platform user
-     * Operation ID: queryCredentials&lt;br&gt; Query S3 credentials of the platform user
-     *
-     * @param offset The start index of credentials to return (optional)
-     * @param limit  Maximum number of credentials to return (optional)
-     * @param filter The conditions to query platform users (optional)
-     * @return S3 credentials of the platform user are returned (status code 200)
-     */
-    @ApiOperation(value = "Query S3 credentials of the platform user", nickname = "queryCredentials", notes = "Operation ID: queryCredentials<br> Query S3 credentials of the platform user ", response = PageOfS3Credentials.class, authorizations = {
-            @Authorization(value = "basicAuth")
-    }, tags = {"s3credential", "required",})
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "S3 credentials of the platform user are returned", response = PageOfS3Credentials.class)})
-    @ApiImplicitParams({
-    })
-    @GetMapping(value = "/api/v1/s3credentials/query",
-            produces = "application/json")
-    public PageOfS3Credentials queryCredentials(
-            @ApiParam(value = "The start index of credentials to return")
-            @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,
-            @ApiParam(value = "Maximum number of credentials to return")
-            @Valid @RequestParam(value = "limit", required = false, defaultValue = "100") long limit,
-            @ApiParam(value = "The conditions to query platform users")
-            @Valid @RequestParam(value = "filter", required = false) String filter) {
-        return this.osisService.queryS3Credentials(offset, limit, filter);
-    }
+        @GetMapping(value = "/api/v1/bucket-logging-id", produces = "application/json")
+        @NotImplement(name = OsisConstants.GET_BUCKET_ID_LOGGING_API_CODE)
+        public OsisBucketLoggingId getBucketLoggingId() {
+                throw new NotImplementedException();
+        }
 
-    @GetMapping(value = "/api/v1/bucket-logging-id",
-            produces = "application/json")
-    @NotImplement(name = OsisConstants.GET_BUCKET_ID_LOGGING_API_CODE)
-    public OsisBucketLoggingId getBucketLoggingId() {
-        throw new NotImplementedException();
-    }
+        @GetMapping(value = "/api/v1/anonymous-user", produces = "application/json")
+        @NotImplement(name = OsisConstants.GET_ANONYMOUS_USER_API_CODE)
+        public OsisUser getAnonymousUser() {
+                throw new NotImplementedException();
+        }
 
-    @GetMapping(value = "/api/v1/anonymous-user",
-            produces = "application/json")
-    @NotImplement(name = OsisConstants.GET_ANONYMOUS_USER_API_CODE)
-    public OsisUser getAnonymousUser() {
-        throw new NotImplementedException();
-    }
-
-    @PostMapping(value = "/api/admin-apis", produces = "application/json")
-    public OsisCaps updateOsisCaps(@RequestBody OsisCaps osisCaps) {
-        return this.osisService.updateOsisCaps(osisCaps);
-    }
+        @PostMapping(value = "/api/admin-apis", produces = "application/json")
+        public OsisCaps updateOsisCaps(@RequestBody OsisCaps osisCaps) {
+                return this.osisService.updateOsisCaps(osisCaps);
+        }
 }
-

--- a/osis-core/src/main/java/com/scality/osis/model/Information.java
+++ b/osis-core/src/main/java/com/scality/osis/model/Information.java
@@ -1,0 +1,331 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class Information {
+  @NotNull
+  private String platformName;
+
+  @NotNull
+  private String platformVersion;
+
+  @NotNull
+  private String apiVersion;
+
+  /**
+   * Gets or Sets status
+   */
+  public enum StatusEnum {
+    NORMAL("NORMAL"),
+    WARNING("WARNING"),
+    ERROR("ERROR"),
+    UNKNOWN("UNKNOWN");
+
+    private String value;
+
+    StatusEnum(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String value) {
+      for (StatusEnum b : StatusEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+  }
+
+  @NotNull
+  private StatusEnum status;
+
+  @Valid
+  @NotNull
+  private List<String> notImplemented = new ArrayList<>();
+
+  private URI logoUri;
+
+  /**
+   * Gets or Sets authModes
+   */
+  public enum AuthModesEnum {
+    BASIC("Basic"),
+    BEARER("Bearer");;
+
+    private String value;
+
+    AuthModesEnum(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static AuthModesEnum fromValue(String value) {
+      for (AuthModesEnum b : AuthModesEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+  }
+
+  @Valid
+  private List<AuthModesEnum> authModes = null;
+
+  private InformationServices services;
+
+  @Valid
+  private List<String> regions = null;
+
+  @Valid
+  private List<String> storageClasses = null;
+
+  public Information platformName(String platformName) {
+    this.platformName = platformName;
+    return this;
+  }
+
+  /**
+   * name of the storage platform
+   * @return platformName
+  */
+  @ApiModelProperty(example = "ceph", required = true, value = "name of the storage platform")
+  public String getPlatformName() {
+    return platformName;
+  }
+
+  public void setPlatformName(String platformName) {
+    this.platformName = platformName;
+  }
+
+  public Information apiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return this;
+  }
+
+  /**
+   * name of the storage platform
+   * @return platformName
+   */
+  @ApiModelProperty(example = "15.2.3", required = true, value = "version of the storage platform")
+  public String getPlatformVersion() {
+    return platformVersion;
+  }
+
+  public void setPlatformVersion(String platformVersion) {
+    this.platformVersion = platformVersion;
+  }
+
+  public Information platformVersion(String platformVersion) {
+    this.platformVersion = platformVersion;
+    return this;
+  }
+
+  /**
+   * OSIS version the REST services complying with
+   * @return apiVersion
+  */
+  @ApiModelProperty(example = "1.0", required = true, value = "OSIS version the REST services complying with")
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public Information status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
+  /**
+   * Get status
+   * @return status
+  */
+  @ApiModelProperty(required = true, value = "")
+  public StatusEnum getStatus() {
+    return status;
+  }
+
+  public void setStatus(StatusEnum status) {
+    this.status = status;
+  }
+
+  public Information notImplemented(List<String> notImplemented) {
+    this.notImplemented = notImplemented;
+    return this;
+  }
+
+  public Information addNotImplementedItem(String notImplementedItem) {
+    this.notImplemented.add(notImplementedItem);
+    return this;
+  }
+
+  /**
+   * the operation id array of optional OSIS APIs which is not implemented
+   * @return notImplemented
+  */
+  @ApiModelProperty(example = "[\"getUsage\",\"getConsole\"]", required = true, value = "the operation id array of optional OSIS APIs which is not implemented")
+  public List<String> getNotImplemented() {
+    return notImplemented;
+  }
+
+  public void setNotImplemented(List<String> notImplemented) {
+    this.notImplemented = notImplemented;
+  }
+
+  public Information logoUri(URI logoUri) {
+    this.logoUri = logoUri;
+    return this;
+  }
+
+  /**
+   * uri of the platform logo so that OSE can use it on UI
+   * @return logoUri
+  */
+  @ApiModelProperty(example = "https://ceph.ose.vmware.com/static/images/ceph.svg", value = "uri of the platform logo so that OSE can use it on UI")
+  @Valid
+  public URI getLogoUri() {
+    return logoUri;
+  }
+
+  public void setLogoUri(URI logoUri) {
+    this.logoUri = logoUri;
+  }
+
+  public Information authModes(List<AuthModesEnum> authModes) {
+    this.authModes = authModes;
+    return this;
+  }
+
+  public Information addAuthModesItem(AuthModesEnum authModesItem) {
+    if (this.authModes == null) {
+      this.authModes = new ArrayList<>();
+    }
+    this.authModes.add(authModesItem);
+    return this;
+  }
+
+  /**
+   * Get authModes
+   * @return authModes
+  */
+  @ApiModelProperty(value = "")
+  public List<AuthModesEnum> getAuthModes() {
+    return authModes;
+  }
+
+  public void setAuthModes(List<AuthModesEnum> authModes) {
+    this.authModes = authModes;
+  }
+
+  public Information services(InformationServices services) {
+    this.services = services;
+    return this;
+  }
+
+  /**
+   * Get services
+   * @return services
+  */
+  @ApiModelProperty(value = "")
+  @Valid
+  public InformationServices getServices() {
+    return services;
+  }
+
+  public void setServices(InformationServices services) {
+    this.services = services;
+  }
+
+  public Information regions(List<String> regions) {
+    this.regions = regions;
+    return this;
+  }
+
+  public Information addRegionsItem(String regionsItem) {
+    if (this.regions == null) {
+      this.regions = new ArrayList<>();
+    }
+    this.regions.add(regionsItem);
+    return this;
+  }
+
+  /**
+   * Get regions
+   * @return regions
+  */
+  @ApiModelProperty(value = "")
+  public List<String> getRegions() {
+    return regions;
+  }
+
+  public void setRegions(List<String> regions) {
+    this.regions = regions;
+  }
+
+  public Information storageClasses(List<String> storageClasses) {
+    this.storageClasses = storageClasses;
+    return this;
+  }
+
+  public Information addStorageClassesItem(String storageClassesItem) {
+    if (this.storageClasses == null) {
+      this.storageClasses = new ArrayList<>();
+    }
+    this.storageClasses.add(storageClassesItem);
+    return this;
+  }
+
+  /**
+   * Get storageClasses
+   * @return storageClasses
+  */
+  @ApiModelProperty(value = "")
+  public List<String> getStorageClasses() {
+    return storageClasses;
+  }
+
+  public void setStorageClasses(List<String> storageClasses) {
+    this.storageClasses = storageClasses;
+  }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/InformationServices.java
+++ b/osis-core/src/main/java/com/scality/osis/model/InformationServices.java
@@ -1,0 +1,52 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class InformationServices {
+  private String s3;
+
+  private String iam;
+
+  public InformationServices s3(String s3) {
+    this.s3 = s3;
+    return this;
+  }
+
+  public InformationServices iam(String iam) {
+    this.iam = iam;
+    return this;
+  }
+
+  /**
+   * S3 URL of the storage platform
+   * @return s3
+  */
+  @ApiModelProperty(example = "https://s3.ceph.ose.vmware.com", value = "S3 URL of the storage platform")
+  public String getS3() {
+    return s3;
+  }
+
+  public void setS3(String s3) {
+    this.s3 = s3;
+  }
+
+  /**
+   * IAM URL of the storage platform
+   * @return iam
+  */
+  @ApiModelProperty(example = "https://iam.ceph.ose.vmware.com", value = "IAM URL of the storage platform")
+  public String getIam() {
+    return iam;
+  }
+
+  public void setIam(String iam) {
+    this.iam = iam;
+  }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/OsisBucketLoggingId.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisBucketLoggingId.java
@@ -1,0 +1,19 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+public class OsisBucketLoggingId {
+    private String loggingId;
+
+    public String getLoggingId() {
+        return loggingId;
+    }
+
+    public void setLoggingId(String loggingId) {
+        this.loggingId = loggingId;
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/model/OsisBucketMeta.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisBucketMeta.java
@@ -1,0 +1,80 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
+
+public class OsisBucketMeta {
+  @NotNull
+  private String name;
+
+  @Valid
+  @NotNull
+  private Instant creationDate;
+
+  @NotNull
+  private String userId;
+
+  public OsisBucketMeta name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public OsisBucketMeta creationDate(Instant creationDate) {
+    this.creationDate = creationDate;
+    return this;
+  }
+
+  public OsisBucketMeta userId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  /**
+   * bucket name
+   * @return name
+  */
+  @ApiModelProperty(required = true, value = "bucket name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * bucket creation date
+   * @return creationDate
+  */
+  @ApiModelProperty(required = true, value = "bucket creation date")
+  public Instant getCreationDate() {
+    return creationDate;
+  }
+
+  public void setCreationDate(Instant creationDate) {
+    this.creationDate = creationDate;
+  }
+
+  /**
+   * user id of bucket owner
+   * @return userId
+  */
+  @ApiModelProperty(required = true, value = "user id of bucket owner")
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/OsisError.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisError.java
@@ -1,0 +1,55 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * a standard error object
+ */
+@ApiModel(description = "a standard error object")
+public class OsisError {
+  @NotNull
+  @JsonProperty("code")
+  private String code;
+
+  @JsonProperty("message")
+  private String message;
+
+  public OsisError code(String code) {
+    this.code = code;
+    return this;
+  }
+
+  @ApiModelProperty(example = "E_BAD_REQUEST", required = true, value = "")
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  public OsisError message(String message) {
+    this.message = message;
+    return this;
+  }
+
+  @ApiModelProperty(example = "invalid value for the property xyz.", value = "")
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/OsisS3Capabilities.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisS3Capabilities.java
@@ -1,0 +1,233 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * Copyright 2022 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.*;
+
+public class OsisS3Capabilities {
+
+    private Map<String, OsisS3CapabilitiesExclusions> exclusions = new HashMap<>();
+
+
+    public OsisS3Capabilities exclusions(Map<String, OsisS3CapabilitiesExclusions> exclusions) {
+
+        this.exclusions = exclusions;
+        return this;
+    }
+
+    public OsisS3Capabilities putExclusionsItem(String key, OsisS3CapabilitiesExclusions exclusionsItem) {
+        this.exclusions.put(key, exclusionsItem);
+        return this;
+    }
+
+    public Map<String, OsisS3CapabilitiesExclusions> getExclusions() {
+        return exclusions;
+    }
+
+
+    public void setExclusions(Map<String, OsisS3CapabilitiesExclusions> exclusions) {
+        this.exclusions = exclusions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OsisS3Capabilities osisS3Capabilities = (OsisS3Capabilities) o;
+        return Objects.equals(this.exclusions, osisS3Capabilities.exclusions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(exclusions);
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OsisS3Capabilities {\n");
+        sb.append("    exclusions: ").append(toIndentedString(exclusions)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class OsisS3CapabilitiesExclusions {
+
+        public static final String JSON_PROPERTY_BY_PARAMS = "by_params";
+        private List<String> byParams = null;
+
+        public static final String JSON_PROPERTY_BY_HEADER = "by_headers";
+        private List<String> byHeaders = null;
+
+        public static final String JSON_PROPERTY_BY_PAYLOAD = "by_payload";
+        private List<String> byPayload = null;
+
+
+        public OsisS3CapabilitiesExclusions byParams(List<String> byParams) {
+
+            this.byParams = byParams;
+            return this;
+        }
+
+        public OsisS3CapabilitiesExclusions addByParamsItem(String byParamsItem) {
+            if (this.byParams == null) {
+                this.byParams = new ArrayList<>();
+            }
+            this.byParams.add(byParamsItem);
+            return this;
+        }
+
+        /**
+         * Get byParams
+         *
+         * @return byParams
+         **/
+        @ApiModelProperty(value = "")
+        @JsonProperty(JSON_PROPERTY_BY_PARAMS)
+        @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+        public List<String> getByParams() {
+            return byParams;
+        }
+
+
+        public void setByParams(List<String> byParams) {
+            this.byParams = byParams;
+        }
+
+
+        public OsisS3CapabilitiesExclusions byHeader(List<String> byHeader) {
+
+            this.byHeaders = byHeader;
+            return this;
+        }
+
+        public OsisS3CapabilitiesExclusions addByHeaderItem(String byHeaderItem) {
+            if (this.byHeaders == null) {
+                this.byHeaders = new ArrayList<>();
+            }
+            this.byHeaders.add(byHeaderItem);
+            return this;
+        }
+
+        /**
+         * Get byHeader
+         *
+         * @return byHeader
+         **/
+        @ApiModelProperty(value = "")
+        @JsonProperty(JSON_PROPERTY_BY_HEADER)
+        @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+        public List<String> getByHeaders() {
+            return byHeaders;
+        }
+
+
+        public void setByHeaders(List<String> byHeaders) {
+            this.byHeaders = byHeaders;
+        }
+
+
+        public OsisS3CapabilitiesExclusions byPayload(List<String> byPayload) {
+
+            this.byPayload = byPayload;
+            return this;
+        }
+
+        public OsisS3CapabilitiesExclusions addByPayloadItem(String byPayloadItem) {
+            if (this.byPayload == null) {
+                this.byPayload = new ArrayList<>();
+            }
+            this.byPayload.add(byPayloadItem);
+            return this;
+        }
+
+        /**
+         * Get byPayload
+         *
+         * @return byPayload
+         **/
+        @ApiModelProperty(value = "")
+        @JsonProperty(JSON_PROPERTY_BY_PAYLOAD)
+        @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+        public List<String> getByPayload() {
+            return byPayload;
+        }
+
+
+        public void setByPayload(List<String> byPayload) {
+            this.byPayload = byPayload;
+        }
+
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            OsisS3CapabilitiesExclusions osisS3CapabilitiesExclusions = (OsisS3CapabilitiesExclusions) o;
+            return Objects.equals(this.byParams, osisS3CapabilitiesExclusions.byParams) &&
+                    Objects.equals(this.byHeaders, osisS3CapabilitiesExclusions.byHeaders) &&
+                    Objects.equals(this.byPayload, osisS3CapabilitiesExclusions.byPayload);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(byParams, byHeaders, byPayload);
+        }
+
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("class OsisS3CapabilitiesExclusions {\n");
+            sb.append("    byParams: ").append(toIndentedString(byParams)).append("\n");
+            sb.append("    byHeader: ").append(toIndentedString(byHeaders)).append("\n");
+            sb.append("    byPayload: ").append(toIndentedString(byPayload)).append("\n");
+            sb.append("}");
+            return sb.toString();
+        }
+
+        /**
+         * Convert the given object to string with each line indented by 4 spaces
+         * (except the first line).
+         */
+        private String toIndentedString(Object o) {
+            if (o == null) {
+                return "null";
+            }
+            return o.toString().replace("\n", "\n    ");
+        }
+
+    }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/OsisS3Credential.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisS3Credential.java
@@ -1,0 +1,218 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
+
+
+public class OsisS3Credential {
+
+  @NotNull
+    private String accessKey;
+
+  @NotNull
+    private String secretKey;
+
+  @NotNull
+  private Boolean active;
+
+  @Valid
+  private Instant creationDate;
+
+  private Boolean immutable;
+
+  private String tenantId;
+
+  private String userId;
+
+  private String username;
+
+  private String cdTenantId;
+
+  private String cdUserId;
+
+  public OsisS3Credential accessKey(String accessKey) {
+    this.accessKey = accessKey;
+    return this;
+  }
+
+  /**
+   * S3 access key
+   * @return accessKey
+  */
+  @ApiModelProperty(example = "00e4a3d674aada749f04", required = true, value = "S3 access key")
+  public String getAccessKey() {
+    return accessKey;
+  }
+
+  public void setAccessKey(String accessKey) {
+    this.accessKey = accessKey;
+  }
+
+  public OsisS3Credential secretKey(String secretKey) {
+    this.secretKey = secretKey;
+    return this;
+  }
+
+  /**
+   * S3 secret key
+   * @return secretKey
+  */
+  @ApiModelProperty(example = "yz8PIwNjmm2zlHX8m7st6BSKh8PCe7bqAaRGkF5K", required = true, value = "S3 secret key")
+  public String getSecretKey() {
+    return secretKey;
+  }
+
+  public void setSecretKey(String secretKey) {
+    this.secretKey = secretKey;
+  }
+
+  public OsisS3Credential active(Boolean active) {
+    this.active = active;
+    return this;
+  }
+
+  /**
+   * S3 credential status
+   * @return active
+  */
+  @ApiModelProperty(example = "true", required = true, value = "S3 credential status")
+  public Boolean getActive() {
+    return active;
+  }
+
+  public void setActive(Boolean active) {
+    this.active = active;
+  }
+
+  public OsisS3Credential creationDate(Instant creationDate) {
+    this.creationDate = creationDate;
+    return this;
+  }
+
+  /**
+   * S3 credential creation date
+   * @return creationDate
+  */
+  @ApiModelProperty(value = "S3 credential creation date")
+  public Instant getCreationDate() {
+    return creationDate;
+  }
+
+  public void setCreationDate(Instant creationDate) {
+    this.creationDate = creationDate;
+  }
+
+  public OsisS3Credential immutable(Boolean immutable) {
+    this.immutable = immutable;
+    return this;
+  }
+
+  /**
+   * S3 credential immutability
+   * @return immutable
+  */
+  @ApiModelProperty(value = "S3 credential immutability")
+  public Boolean getImmutable() {
+    return immutable;
+  }
+
+  public void setImmutable(Boolean immutable) {
+    this.immutable = immutable;
+  }
+
+  public OsisS3Credential tenantId(String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  /**
+   * The ID of the tenant which the S3 credential belongs to
+   * @return tenantId
+  */
+  @ApiModelProperty(example = "acme", value = "The ID of the tenant which the S3 credential belongs to")
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public OsisS3Credential cdTenantId(String cdTenantId) {
+    this.cdTenantId = cdTenantId;
+    return this;
+  }
+
+  /**
+   * The ID of the tenant which the S3 credential belongs to
+   * @return tenantId
+   */
+  @ApiModelProperty(example = "acme", value = "The ID of the Cloud Director tenant which the S3 credential belongs to")
+  public String getCdTenantId() {
+    return cdTenantId;
+  }
+
+  public void setCdTenantId(String cdTenantId) {
+    this.cdTenantId = cdTenantId;
+  }
+
+  public OsisS3Credential userId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  /**
+   * The ID of the user which the S3 credential belongs to
+   * @return userId
+  */
+  @ApiModelProperty(example = "961515dd-8348-4cac-8780-5edcb8a87b58", value = "The ID of the user which the S3 credential belongs to")
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  public OsisS3Credential username(String username) {
+    this.username = username;
+    return this;
+  }
+
+  /**
+   * The name of the user which the S3 credential belongs to
+   * @return username
+   */
+  @ApiModelProperty(example = "rachelw", value = "The name of the user which the S3 credential belongs to")
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public OsisS3Credential cdUserId(String cdUserId) {
+    this.cdUserId = cdUserId;
+    return this;
+  }
+
+  @ApiModelProperty(example = "961515dd-8348-4cac-8780-5edcb8a87b58", value = "The ID of the Cloud Director user which the S3 credential belongs to")
+  public String getCdUserId() {
+    return cdUserId;
+  }
+
+  public void setCdUserId(String cdUserId) {
+    this.cdUserId = cdUserId;
+  }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/OsisTenant.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisTenant.java
@@ -1,0 +1,138 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OsisTenant {
+
+//  @NotNull
+  private boolean active;
+
+//  @NotNull
+  private String name;
+
+//  @NotNull
+  private String tenantId;
+
+  private List<String> cdTenantIds;
+
+
+
+  public OsisTenant active(boolean active) {
+    this.active = active;
+    return this;
+  }
+
+  public boolean getActive() {
+    return this.active;
+  }
+
+  public OsisTenant name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * tenant name
+   * @return name
+  */
+  @ApiModelProperty(example = "ACME", required = true, value = "tenant name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * tenant status
+   * @return active
+  */
+
+  public OsisTenant tenantId(String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  /**
+   * tenant id
+   * @return tenantId
+  */
+  @ApiModelProperty(example = "d290f1ee-6c54-4b01-90e6-d701748f0851", required = true, value = "tenant id")
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public OsisTenant cdTenantIds(List<String> cdTenantIds) {
+    this.cdTenantIds= cdTenantIds;
+    return this;
+  }
+
+  public OsisTenant addCdTenantId(String cdTenantId) {
+    if (this.cdTenantIds == null) {
+      this.cdTenantIds = new ArrayList<>();
+    }
+    this.cdTenantIds.add(cdTenantId);
+    return this;
+  }
+
+  /**
+   * Cloud Director tenant id
+   * @return cdTenantIds
+  */
+  @ApiModelProperty(example = "8daca9a9-5b11-4f63-9c52-953a2ef77739", required = true, value = "Cloud Director tenant id")
+  public List<String> getCdTenantIds() {
+    return cdTenantIds;
+  }
+
+  public void setCdTenantIds(List<String> cdTenantIds) {
+    this.cdTenantIds = cdTenantIds;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    OsisTenant that = (OsisTenant) o;
+
+    if (active != that.active) {
+      return false;
+    }
+    if (name != null ? !name.equals(that.name) : that.name != null) {
+      return false;
+    }
+    if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) {
+      return false;
+    }
+    return cdTenantIds != null ? cdTenantIds.equals(that.cdTenantIds) : that.cdTenantIds == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (active ? 1 : 0);
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
+    result = 31 * result + (cdTenantIds != null ? cdTenantIds.hashCode() : 0);
+    return result;
+  }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/OsisUsage.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisUsage.java
@@ -1,0 +1,132 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
+public class OsisUsage {
+    @NotNull
+    private Long bucketCount;
+
+    @NotNull
+    private Long objectCount;
+
+    @NotNull
+    private Long totalBytes;
+
+    @NotNull
+    private Long availableBytes;
+
+    @NotNull
+    private Long usedBytes;
+
+    public OsisUsage() {
+        totalBytes = 0L;
+        availableBytes = 0L;
+        usedBytes = 0L;
+        bucketCount = 0L;
+        objectCount = 0L;
+    }
+
+    public OsisUsage bucketCount(Long bucketCount) {
+        this.bucketCount = bucketCount;
+        return this;
+    }
+
+    /**
+     * bucket count of tenant or user
+     *
+     * @return bucketCount
+     */
+    @ApiModelProperty(example = "532", required = true, value = "bucket count of tenant or user")
+    public Long getBucketCount() {
+        return bucketCount;
+    }
+
+    public void setBucketCount(Long bucketCount) {
+        this.bucketCount = bucketCount;
+    }
+
+    public OsisUsage objectCount(Long objectCount) {
+        this.objectCount = objectCount;
+        return this;
+    }
+
+    /**
+     * object count of tenant or user
+     *
+     * @return objectCount
+     */
+    @ApiModelProperty(example = "298635", required = true, value = "object count of tenant or user")
+    public Long getObjectCount() {
+        return objectCount;
+    }
+
+    public void setObjectCount(Long objectCount) {
+        this.objectCount = objectCount;
+    }
+
+    public OsisUsage totalBytes(Long totalBytes) {
+        this.totalBytes = totalBytes;
+        return this;
+    }
+
+    /**
+     * total storage bytes of tenant or user
+     *
+     * @return totalBytes
+     */
+    @ApiModelProperty(example = "80948230763", required = true, value = "total storage bytes of tenant or user")
+    public Long getTotalBytes() {
+        return totalBytes;
+    }
+
+    public void setTotalBytes(Long totalBytes) {
+        this.totalBytes = totalBytes;
+    }
+
+    public OsisUsage avaialbleBytes(Long avaialbleBytes) {
+        this.availableBytes = avaialbleBytes;
+        return this;
+    }
+
+    /**
+     * available storage bytes of tenant or user
+     *
+     * @return avaialbleBytes
+     */
+    @ApiModelProperty(example = "48193854929", required = true, value = "available storage bytes of tenant or user")
+    public Long getAvailableBytes() {
+        return availableBytes;
+    }
+
+    public void setAvailableBytes(Long availableBytes) {
+        this.availableBytes = availableBytes;
+    }
+
+    public OsisUsage usedBytes(Long usedBytes) {
+        this.usedBytes = usedBytes;
+        return this;
+    }
+
+    /**
+     * used storage bytes of tenant or user
+     *
+     * @return usedBytes
+     */
+    @ApiModelProperty(example = "32754375834", required = true, value = "used storage bytes of tenant or user")
+    public Long getUsedBytes() {
+        return usedBytes;
+    }
+
+    public void setUsedBytes(Long usedBytes) {
+        this.usedBytes = usedBytes;
+    }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/OsisUser.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisUser.java
@@ -1,0 +1,264 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.vmware.osis.validation.Update;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+public class OsisUser {
+
+  private String userId;
+
+  private String canonicalUserId;
+
+  private String tenantId;
+
+  @NotNull(groups = {Update.class})
+  private Boolean active;
+
+  private String cdUserId;
+
+  private String cdTenantId;
+
+  private String username;
+
+  @Email
+  private String email;
+
+  @JsonIgnore
+  private List<OsisS3Credential> osisS3Credentials;
+
+  /**
+   * user role
+   */
+  public enum RoleEnum {
+    PROVIDER_ADMIN("PROVIDER_ADMIN"),
+
+    TENANT_ADMIN("TENANT_ADMIN"),
+    
+    TENANT_USER("TENANT_USER"),
+    
+    ANONYMOUS("ANONYMOUS"),
+    
+    UNKNOWN("UNKNOWN");
+
+    private String value;
+
+
+    RoleEnum(String value) {
+      this.value = value;
+    }
+
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static RoleEnum fromValue(String value) {
+      for (RoleEnum b : RoleEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+
+//
+  }
+
+  private RoleEnum role;
+
+  public OsisUser userId(String userId) {
+    this.userId = userId;
+    return this;
+  }
+
+  /**
+   * user id
+   * @return userId
+  */
+  @ApiModelProperty(example = "rachelw", required = true, value = "user id")
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  public OsisUser canonicalUserId(String canonicalUserId) {
+    this.canonicalUserId = canonicalUserId;
+    return this;
+  }
+
+  /**
+   * canonical user id
+   * @return canonicalUserId
+  */
+  @ApiModelProperty(example = "68fb0f20-4a0c-4036-a584-cc3ee421093f", required = true, value = "canonical user id")
+  public String getCanonicalUserId() {
+    return canonicalUserId;
+  }
+
+  public void setCanonicalUserId(String canonicalUserId) {
+    this.canonicalUserId = canonicalUserId;
+  }
+
+  public OsisUser tenantId(String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  /**
+   * id of the tenant which the user belongs to
+   * @return tenantId
+  */
+  @ApiModelProperty(example = "bb8287a9-874e-46d2-abbd-58278e1ac046", required = true, value = "id of the tenant which the user belongs to")
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public OsisUser active(Boolean active) {
+    this.active = active;
+    return this;
+  }
+
+  /**
+   * user status
+   * @return active
+  */
+  @ApiModelProperty(required = true, value = "user status")
+  public Boolean getActive() {
+    return active;
+  }
+
+  public void setActive(Boolean active) {
+    this.active = active;
+  }
+
+  public OsisUser cdUserId(String cdUserId) {
+    this.cdUserId = cdUserId;
+    return this;
+  }
+
+  /**
+   * Cloud Director user id
+   * @return cdUserId
+  */
+  @ApiModelProperty(example = "rachelw", required = true, value = "Cloud Director user id")
+  public String getCdUserId() {
+    return cdUserId;
+  }
+
+  public void setCdUserId(String cdUserId) {
+    this.cdUserId = cdUserId;
+  }
+
+  public OsisUser cdTenantId(String cdTenantId) {
+    this.cdTenantId = cdTenantId;
+    return this;
+  }
+
+  /**
+   * id of Cloud Director tenant which the user belongs to
+   * @return cdTenantId
+  */
+  @ApiModelProperty(example = "40b97e3c-c3b1-4251-b7de-e9637324683f", required = true, value = "id of Cloud Director tenant which the user belongs to")
+  public String getCdTenantId() {
+    return cdTenantId;
+  }
+
+  public void setCdTenantId(String cdTenantId) {
+    this.cdTenantId = cdTenantId;
+  }
+
+  public OsisUser displayName(String displayName) {
+    this.username = displayName;
+    return this;
+  }
+
+  /**
+   * user display name
+   * @return displayName
+  */
+  @ApiModelProperty(value = "user display name")
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public OsisUser email(String email) {
+    this.email = email;
+    return this;
+  }
+
+  /**
+   * user email
+   * @return email
+  */
+  @ApiModelProperty(example = "rachelw@acme.com", value = "user email")
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public OsisUser role(RoleEnum role) {
+    this.role = role;
+    return this;
+  }
+
+  /**
+   * user role
+   * @return role
+  */
+  @ApiModelProperty(value = "user role")
+  public RoleEnum getRole() {
+    return role;
+  }
+
+  public void setRole(RoleEnum role) {
+    this.role = role;
+  }
+
+  public OsisUser osisS3Credentials(List<OsisS3Credential> osisS3Credentials) {
+    this.osisS3Credentials = osisS3Credentials;
+    return this;
+  }
+
+  public List<OsisS3Credential> getOsisS3Credentials() {
+    return osisS3Credentials;
+  }
+
+  public void setOsisS3Credentials(List<OsisS3Credential> osisS3Credentials) {
+    this.osisS3Credentials = osisS3Credentials;
+  }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/Page.java
+++ b/osis-core/src/main/java/com/scality/osis/model/Page.java
@@ -1,0 +1,20 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import java.util.List;
+
+public interface Page<T> {
+
+    List<T> getItems();
+
+    void setItems(List<T> items);
+
+    Page<T> pageInfo(PageInfo pageInfo);
+
+    void setPageInfo(PageInfo pageInfo);
+}

--- a/osis-core/src/main/java/com/scality/osis/model/PageInfo.java
+++ b/osis-core/src/main/java/com/scality/osis/model/PageInfo.java
@@ -1,0 +1,106 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
+public class PageInfo {
+  @NotNull
+  private Long limit;
+
+  @NotNull
+  private Long offset;
+
+  @NotNull
+  private Long total;
+
+  public PageInfo limit(Long limit) {
+    this.limit = limit;
+    return this;
+  }
+
+  /**
+   * maxium number of the items in each page
+   * @return limit
+  */
+  @ApiModelProperty(required = true, value = "maxium number of the items in each page")
+  public Long getLimit() {
+    return limit;
+  }
+
+  public void setLimit(Long limit) {
+    this.limit = limit;
+  }
+
+  public PageInfo offset(Long offset) {
+    this.offset = offset;
+    return this;
+  }
+
+  /**
+   * offset of the current page in the whole set of items
+   * @return offset
+  */
+  @ApiModelProperty(required = true, value = "offset of the current page in the whole set of items")
+  public Long getOffset() {
+    return offset;
+  }
+
+  public void setOffset(Long offset) {
+    this.offset = offset;
+  }
+
+  public PageInfo total(Long total) {
+    this.total = total;
+    return this;
+  }
+
+  /**
+   * total number of the items
+   * @return total
+  */
+  @ApiModelProperty(required = true, value = "total number of the items")
+  public Long getTotal() {
+    return total;
+  }
+
+  public void setTotal(Long total) {
+    this.total = total;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PageInfo pageInfo = (PageInfo) o;
+
+    if (limit != null ? !limit.equals(pageInfo.limit) : pageInfo.limit != null) {
+      return false;
+    }
+    if (offset != null ? !offset.equals(pageInfo.offset) : pageInfo.offset != null) {
+      return false;
+    }
+    return total != null ? total.equals(pageInfo.total) : pageInfo.total == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = limit != null ? limit.hashCode() : 0;
+    result = 31 * result + (offset != null ? offset.hashCode() : 0);
+    result = 31 * result + (total != null ? total.hashCode() : 0);
+    return result;
+  }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/PageOfOsisBucketMeta.java
+++ b/osis-core/src/main/java/com/scality/osis/model/PageOfOsisBucketMeta.java
@@ -1,0 +1,55 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PageOfOsisBucketMeta implements Page<OsisBucketMeta> {
+    private List<OsisBucketMeta> items;
+
+    private PageInfo pageInfo;
+
+    public PageOfOsisBucketMeta items(List<OsisBucketMeta> items) {
+        this.items = items;
+        return this;
+    }
+
+    public PageOfOsisBucketMeta addItem(OsisBucketMeta item) {
+        if(this.items == null) {
+            this.items = new ArrayList<>();
+        }
+        this.items.add(item);
+        return this;
+    }
+
+
+    @Override
+    public List<OsisBucketMeta> getItems() {
+        return items;
+    }
+
+    public PageInfo getPageInfo() {
+        return pageInfo;
+    }
+
+    @Override
+    public void setItems(List<OsisBucketMeta> items) {
+        this.items = items;
+    }
+
+    @Override
+    public PageOfOsisBucketMeta pageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+        return this;
+    }
+
+    @Override
+    public void setPageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/model/PageOfS3Credentials.java
+++ b/osis-core/src/main/java/com/scality/osis/model/PageOfS3Credentials.java
@@ -1,0 +1,67 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PageOfS3Credentials implements Page<OsisS3Credential> {
+    @Valid
+    private List<OsisS3Credential> items = null;
+
+    private PageInfo pageInfo;
+
+    public PageOfS3Credentials items(List<OsisS3Credential> items) {
+        this.items = items;
+        return this;
+    }
+
+    public PageOfS3Credentials addItemsItem(OsisS3Credential itemsItem) {
+        if (this.items == null) {
+            this.items = new ArrayList<>();
+        }
+        this.items.add(itemsItem);
+        return this;
+    }
+
+    /**
+     * Get items
+     *
+     * @return items
+     */
+    @ApiModelProperty(value = "")
+    public List<OsisS3Credential> getItems() {
+        return items;
+    }
+
+    public void setItems(List<OsisS3Credential> items) {
+        this.items = items;
+    }
+
+    public PageOfS3Credentials pageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+        return this;
+    }
+
+    /**
+     * Get pageInfo
+     *
+     * @return pageInfo
+     */
+    @ApiModelProperty(value = "")
+    public PageInfo getPageInfo() {
+        return pageInfo;
+    }
+
+    public void setPageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+    }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/PageOfTenants.java
+++ b/osis-core/src/main/java/com/scality/osis/model/PageOfTenants.java
@@ -1,0 +1,95 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PageOfTenants implements Page<OsisTenant> {
+    @Valid
+    private List<OsisTenant> items = null;
+
+    private PageInfo pageInfo;
+
+    public PageOfTenants items(List<OsisTenant> items) {
+        this.items = items;
+        return this;
+    }
+
+    public PageOfTenants addItemsItem(OsisTenant itemsItem) {
+        if (this.items == null) {
+            this.items = new ArrayList<>();
+        }
+        this.items.add(itemsItem);
+        return this;
+    }
+
+    /**
+     * Get items
+     *
+     * @return items
+     */
+    @Override
+    @ApiModelProperty(value = "")
+    public List<OsisTenant> getItems() {
+        return items;
+    }
+
+    @Override
+    public void setItems(List<OsisTenant> items) {
+        this.items = items;
+    }
+
+    @Override
+    public PageOfTenants pageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+        return this;
+    }
+
+    /**
+     * Get pageInfo
+     *
+     * @return pageInfo
+     */
+    @ApiModelProperty(value = "")
+    public PageInfo getPageInfo() {
+        return pageInfo;
+    }
+
+    @Override
+    public void setPageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PageOfTenants that = (PageOfTenants) o;
+
+        if (!items.equals(that.items)) {
+            return false;
+        }
+        return pageInfo.equals(that.pageInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = items.hashCode();
+        result = 31 * result + pageInfo.hashCode();
+        return result;
+    }
+}
+

--- a/osis-core/src/main/java/com/scality/osis/model/PageOfUsers.java
+++ b/osis-core/src/main/java/com/scality/osis/model/PageOfUsers.java
@@ -1,0 +1,67 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PageOfUsers implements Page<OsisUser> {
+    @Valid
+    private List<OsisUser> items = null;
+
+    private PageInfo pageInfo;
+
+    public PageOfUsers items(List<OsisUser> items) {
+        this.items = items;
+        return this;
+    }
+
+    public PageOfUsers addItemsItem(OsisUser itemsItem) {
+        if (this.items == null) {
+            this.items = new ArrayList<>();
+        }
+        this.items.add(itemsItem);
+        return this;
+    }
+
+    /**
+     * Get items
+     *
+     * @return items
+     */
+    @ApiModelProperty(value = "")
+    public List<OsisUser> getItems() {
+        return items;
+    }
+
+    public void setItems(List<OsisUser> items) {
+        this.items = items;
+    }
+
+    public PageOfUsers pageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+        return this;
+    }
+
+    /**
+     * Get pageInfo
+     *
+     * @return pageInfo
+     */
+    @ApiModelProperty(value = "")
+    public PageInfo getPageInfo() {
+        return pageInfo;
+    }
+
+    public void setPageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+    }
+
+}

--- a/osis-core/src/main/java/com/scality/osis/model/ScalityOsisConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/model/ScalityOsisConstants.java
@@ -8,12 +8,22 @@ package com.scality.osis.model;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.vmware.osis.model.OsisConstants.*;
 
 public final class ScalityOsisConstants {
     private ScalityOsisConstants() {
 
     }
+
+    public static final String GET_TENANT_API_CODE = "getTenant";
+    public static final String DELETE_TENANT_API_CODE = "deleteTenant";
+    public static final String HEAD_USER_API_CODE = "headUser";
+    public static final String UPDATE_CREDENTIAL_STATUS_API_CODE = "updateCredentialStatus";
+    public static final String DELETE_CREDENTIAL_API_CODE = "deleteCredential";
+    public static final String GET_USAGE_API_CODE = "getUsage";
+    public static final String GET_BUCKET_LIST_API_CODE = "getBucketList";
+    public static final String GET_BUCKET_ID_LOGGING_API_CODE = "getBucketLoggingId";
+    public static final String GET_ANONYMOUS_USER_API_CODE = "getAnonymousUser";
+    public static final String GET_CONSOLE_API_CODE = "getConsole";
 
     public static final List<String> API_CODES = Arrays.asList(GET_TENANT_API_CODE,
             DELETE_TENANT_API_CODE, HEAD_USER_API_CODE, UPDATE_CREDENTIAL_STATUS_API_CODE,

--- a/osis-core/src/main/java/com/scality/osis/model/exception/BadRequestException.java
+++ b/osis-core/src/main/java/com/scality/osis/model/exception/BadRequestException.java
@@ -1,0 +1,21 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class BadRequestException extends ResponseStatusException {
+
+    public BadRequestException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
+
+    public BadRequestException(String message, Throwable throwable) {
+        super(HttpStatus.BAD_REQUEST, message, throwable);
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/model/exception/InternalException.java
+++ b/osis-core/src/main/java/com/scality/osis/model/exception/InternalException.java
@@ -1,0 +1,21 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class InternalException extends ResponseStatusException {
+
+    public InternalException(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message);
+    }
+
+    public InternalException(String message, Throwable throwable) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message, throwable);
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/model/exception/NotFoundException.java
+++ b/osis-core/src/main/java/com/scality/osis/model/exception/NotFoundException.java
@@ -1,0 +1,17 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class NotFoundException extends ResponseStatusException {
+
+    public NotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/model/exception/NotImplementedException.java
+++ b/osis-core/src/main/java/com/scality/osis/model/exception/NotImplementedException.java
@@ -1,0 +1,17 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class NotImplementedException extends ResponseStatusException {
+
+    public NotImplementedException() {
+        super(HttpStatus.NOT_IMPLEMENTED, "The interface is not implemented.");
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
@@ -6,10 +6,9 @@
 
 package com.scality.osis.service;
 
-import com.vmware.osis.model.OsisS3Credential;
+import com.scality.osis.model.OsisS3Credential;
 import com.vmware.osis.service.OsisService;
 
 public interface ScalityOsisService extends OsisService {
     OsisS3Credential getS3Credential(String tenantId, String userId, String accessKey);
 }
-

--- a/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
@@ -6,9 +6,67 @@
 
 package com.scality.osis.service;
 
+import com.scality.osis.model.*;
+import com.scality.osis.model.ScalityOsisCaps;
 import com.scality.osis.model.OsisS3Credential;
-import com.vmware.osis.service.OsisService;
 
-public interface ScalityOsisService extends OsisService {
+import java.util.Optional;
+
+public interface ScalityOsisService {
+
     OsisS3Credential getS3Credential(String tenantId, String userId, String accessKey);
+
+    OsisTenant createTenant(OsisTenant osisTenant);
+
+    PageOfTenants queryTenants(long offset, long limit, String filter);
+
+    PageOfTenants listTenants(long offset, long limit);
+
+    OsisTenant getTenant(String tenantId);
+
+    boolean headTenant(String tenantId);
+
+    void deleteTenant(String tenantId, Boolean purgeData);
+
+    OsisTenant updateTenant(String tenantId, OsisTenant osisTenant);
+
+    OsisUser createUser(OsisUser osisUser);
+
+    PageOfUsers queryUsers(long offset, long limit, String filter);
+
+    void deleteUser(String tenantId, String userId, Boolean purgeData);
+
+    OsisUser getUser(String canonicalUserId);
+
+    OsisUser getUser(String tenantId, String userId);
+
+    PageOfUsers listUsers(String tenantId, long offset, long limit);
+
+    OsisUser updateUser(String tenantId, String userId, OsisUser osisUser);
+
+    boolean headUser(String tenantId, String userId);
+
+    OsisS3Credential createS3Credential(String tenantId, String userId);
+
+    PageOfS3Credentials queryS3Credentials(long offset, long limit, String filter);
+
+    void deleteS3Credential(String tenantId, String userId, String accessKey);
+
+    OsisS3Credential getS3Credential(String accessKey);
+
+    PageOfS3Credentials listS3Credentials(String tenantId, String userId, Long offset, Long limit);
+
+    String getProviderConsoleUrl();
+
+    String getTenantConsoleUrl(String tenantId);
+
+    OsisS3Capabilities getS3Capabilities();
+
+    Information getInformation(String domain);
+
+    ScalityOsisCaps updateOsisCaps(ScalityOsisCaps osisCaps);
+
+    PageOfOsisBucketMeta getBucketList(String tenantId, long offset, long limit);
+
+    OsisUsage getOsisUsage(Optional<String> tenantId, Optional<String> userId);
 }

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -1020,7 +1020,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
     }
 
     @Override
-    public OsisCaps updateOsisCaps(OsisCaps osisCaps) {
+    public ScalityOsisCaps updateOsisCaps(ScalityOsisCaps osisCaps) {
         throw new NotImplementedException();
     }
 

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -14,14 +14,14 @@ import com.scality.vaultclient.dto.GetAccountRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
 import com.scality.vaultclient.dto.UpdateAccountAttributesRequestDTO;
-import com.vmware.osis.model.OsisS3Credential;
-import com.vmware.osis.model.OsisTenant;
-import com.vmware.osis.model.OsisUser;
-import com.vmware.osis.model.PageInfo;
-import com.vmware.osis.model.PageOfS3Credentials;
-import com.vmware.osis.model.PageOfTenants;
-import com.vmware.osis.model.PageOfUsers;
-import com.vmware.osis.model.exception.BadRequestException;
+import com.scality.osis.model.OsisS3Credential;
+import com.scality.osis.model.OsisTenant;
+import com.scality.osis.model.OsisUser;
+import com.scality.osis.model.PageInfo;
+import com.scality.osis.model.PageOfS3Credentials;
+import com.scality.osis.model.PageOfTenants;
+import com.scality.osis.model.PageOfUsers;
+import com.scality.osis.model.exception.BadRequestException;
 import com.scality.vaultclient.dto.AccountData;
 import com.scality.vaultclient.dto.CreateAccountRequestDTO;
 import com.scality.vaultclient.dto.CreateAccountResponseDTO;
@@ -42,21 +42,24 @@ import static com.scality.osis.utils.ScalityConstants.*;
  */
 public final class ScalityModelConverter {
 
-
     private ScalityModelConverter() {
     }
 
-    /* All Converter methods below converts OSIS model objects to Vault/Scality request formats */
+    /*
+     * All Converter methods below converts OSIS model objects to Vault/Scality
+     * request formats
+     */
 
     /**
      * Converts OSIS Tenant object to Vault Create Account request
+     * 
      * @param osisTenant the osis tenant
      *
      * @return the create account request dto
      */
     public static CreateAccountRequestDTO toScalityCreateAccountRequest(OsisTenant osisTenant) {
-        if(!osisTenant.getActive()){
-//            Scality does not support inactive tenant creation
+        if (!osisTenant.getActive()) {
+            // Scality does not support inactive tenant creation
             throw new BadRequestException("Creating inactive tenant is not supported");
         }
         CreateAccountRequestDTO createAccountRequestDTO = new CreateAccountRequestDTO();
@@ -75,13 +78,14 @@ public final class ScalityModelConverter {
 
     /**
      * Converts OSIS Tenant object to Vault Update Account Attributes request
+     * 
      * @param osisTenant the osis tenant
      *
      * @return the update account attributes request dto
      */
     public static UpdateAccountAttributesRequestDTO toUpdateAccountAttributesRequestDTO(OsisTenant osisTenant) {
-        if(!osisTenant.getActive()){
-//            Scality does not support inactive tenants
+        if (!osisTenant.getActive()) {
+            // Scality does not support inactive tenants
             throw new BadRequestException("Deactivating a tenant is not supported");
         }
         UpdateAccountAttributesRequestDTO updateAccountAttributesRequestDTO = new UpdateAccountAttributesRequestDTO();
@@ -95,6 +99,7 @@ public final class ScalityModelConverter {
 
     /**
      * Created Vault List Accounts request for List Tenants
+     * 
      * @param limit the max number of items
      *
      * @return the create account request dto
@@ -108,10 +113,11 @@ public final class ScalityModelConverter {
 
     /**
      * Creates Vault List Users request for List users
-     * @param limit the max number of items
+     * 
+     * @param limit  the max number of items
      *
      * @param offset the starting offset of the users list
-     * @param limit the max number of the users in the response
+     * @param limit  the max number of the users in the response
      * @return the IAM list users request dto
      */
     public static ListUsersRequest toIAMListUsersRequest(Long offset, Long limit) {
@@ -124,7 +130,7 @@ public final class ScalityModelConverter {
      * Creates Vault List Access Keys request
      *
      * @param username the IAM User's username
-     * @param limit the max number of the access keys in the response
+     * @param limit    the max number of the access keys in the response
      * @return the IAM list Access Keys request dto
      */
     public static ListAccessKeysRequest toIAMListAccessKeysRequest(String username, Long limit) {
@@ -137,10 +143,11 @@ public final class ScalityModelConverter {
      * Creates Vault Update Access Key request
      *
      * @param username the IAM User's username
-     * @param limit the max number of the access keys in the response
+     * @param limit    the max number of the access keys in the response
      * @return the IAM list Access Keys request dto
      */
-    public static UpdateAccessKeyRequest toIAMUpdateAccessKeyRequest(String username, String accessKey, Boolean isActive) {
+    public static UpdateAccessKeyRequest toIAMUpdateAccessKeyRequest(String username, String accessKey,
+            Boolean isActive) {
         return new UpdateAccessKeyRequest()
                 .withUserName(username)
                 .withAccessKeyId(accessKey)
@@ -149,6 +156,7 @@ public final class ScalityModelConverter {
 
     /**
      * Creates IAM Get User request
+     * 
      * @param username Vault username
      *
      * @return the IAM get user request dto
@@ -160,6 +168,7 @@ public final class ScalityModelConverter {
 
     /**
      * Creates IAM Delete User request
+     * 
      * @param username Vault username
      *
      * @return the IAM delete user request dto
@@ -171,6 +180,7 @@ public final class ScalityModelConverter {
 
     /**
      * Created Vault List Accounts request for Query Tenants
+     * 
      * @param limit the max number of items
      *
      * @return the create account request dto
@@ -184,6 +194,7 @@ public final class ScalityModelConverter {
 
     /**
      * Creates Vault Assume Role request request for given account id
+     * 
      * @param accountID the account ID
      *
      * @return the assume role request dto
@@ -195,14 +206,16 @@ public final class ScalityModelConverter {
     }
 
     /**
-     * Creates GenerateAccountAccessKeyRequest dto for given account id and duration in seconds
-     * @param accountID the account ID
+     * Creates GenerateAccountAccessKeyRequest dto for given account id and duration
+     * in seconds
+     * 
+     * @param accountID       the account ID
      * @param durationSeconds the duration in seconds
      *
      * @return the GenerateAccountAccessKeyRequest dto
      */
     public static GenerateAccountAccessKeyRequest toGenerateAccountAccessKeyRequest(String accountID,
-                                                                                    long durationSeconds) {
+            long durationSeconds) {
         return GenerateAccountAccessKeyRequest.builder()
                 .accountName(accountID)
                 .durationSeconds(durationSeconds)
@@ -211,6 +224,7 @@ public final class ScalityModelConverter {
 
     /**
      * Creates CreateRoleRequest dto
+     * 
      * @param assumeRoleName the role name
      *
      * @return the CreateRoleRequest dto
@@ -223,6 +237,7 @@ public final class ScalityModelConverter {
 
     /**
      * Creates CreatePolicyRequest dto for admin policy for OSIS role
+     * 
      * @param tenantId the account id
      *
      * @return the CreatePolicyRequest dto
@@ -236,8 +251,9 @@ public final class ScalityModelConverter {
 
     /**
      * Creates AttachRolePolicyRequest dto for attaching admin policy to OSIS role
+     * 
      * @param policyArn the policy arn
-     * @param roleName the OSIS role name
+     * @param roleName  the OSIS role name
      *
      * @return the AttachRolePolicyRequest dto
      */
@@ -249,8 +265,9 @@ public final class ScalityModelConverter {
 
     /**
      * Creates DeleteAccessKeyRequest dto
+     * 
      * @param accessKeyId the accesskeyId
-     * @param username the username
+     * @param username    the username
      *
      * @return the DeleteAccessKeyRequest dto
      */
@@ -258,7 +275,7 @@ public final class ScalityModelConverter {
         DeleteAccessKeyRequest deleteAccessKeyRequest = new DeleteAccessKeyRequest()
                 .withAccessKeyId(accessKeyId);
 
-        if(!StringUtils.isEmpty(username)) {
+        if (!StringUtils.isEmpty(username)) {
             deleteAccessKeyRequest.setUserName(username);
         }
 
@@ -267,6 +284,7 @@ public final class ScalityModelConverter {
 
     /**
      * Creates GetAccountRequestDTO
+     * 
      * @param accountID the accountID
      *
      * @return the GetAccountRequestDTO
@@ -279,6 +297,7 @@ public final class ScalityModelConverter {
 
     /**
      * Creates GetAccountRequestDTO using canonicalID
+     * 
      * @param canonicalID the canonicalID
      *
      * @return the GetAccountRequestDTO
@@ -304,19 +323,21 @@ public final class ScalityModelConverter {
     }
 
     public static CreateUserRequest toCreateUserRequest(OsisUser osisUser) {
-        OsisUser.RoleEnum role = (osisUser.getRole() != null) ? osisUser.getRole() :OsisUser.RoleEnum.UNKNOWN ;
+        OsisUser.RoleEnum role = (osisUser.getRole() != null) ? osisUser.getRole() : OsisUser.RoleEnum.UNKNOWN;
         return new CreateUserRequest()
                 .withUserName(osisUser.getCdUserId())
                 .withPath(
                         toUserPath(osisUser.getUsername(),
-                                    role,
-                                    osisUser.getEmail(),
-                                    osisUser.getCdTenantId(),
-                                    osisUser.getCanonicalUserId()));
+                                role,
+                                osisUser.getEmail(),
+                                osisUser.getCdTenantId(),
+                                osisUser.getCanonicalUserId()));
     }
 
-    private static String toUserPath(String username, OsisUser.RoleEnum role, String email, String cdTenantId, String canonicalUserId) {
-        return USER_PATH_SEPARATOR + username + USER_PATH_SEPARATOR + role.getValue() + USER_PATH_SEPARATOR + email + USER_PATH_SEPARATOR + cdTenantId + USER_PATH_SEPARATOR
+    private static String toUserPath(String username, OsisUser.RoleEnum role, String email, String cdTenantId,
+            String canonicalUserId) {
+        return USER_PATH_SEPARATOR + username + USER_PATH_SEPARATOR + role.getValue() + USER_PATH_SEPARATOR + email
+                + USER_PATH_SEPARATOR + cdTenantId + USER_PATH_SEPARATOR
                 + canonicalUserId + USER_PATH_SEPARATOR;
     }
 
@@ -372,7 +393,7 @@ public final class ScalityModelConverter {
 
     /**
      * Generates tenant email string using tenant name.
-     *  example email address: tenant.name@osis.scality.com
+     * example email address: tenant.name@osis.scality.com
      *
      * @param name the name
      * @return the string
@@ -384,23 +405,25 @@ public final class ScalityModelConverter {
     /**
      * Converts OSIS cdTenantIDs list to Vault Account customAttributes Map Format
      *
-     * @param cdTenantIds the cd tenant ids list. Example:<code>["9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf"]</code>
+     * @param cdTenantIds the cd tenant ids list.
+     *                    Example:<code>["9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf"]</code>
      * @return the customAttributes map.
-     *          Example: <code>{("cd_tenant_id==9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
+     *         Example:
+     *         <code>{("cd_tenant_id==9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
      *                          ("cd_tenant_id==7b7e3259-aace-414c-bfd8-94daa0efefaf", "")}</code>
      */
-    public static Map<String,String> toScalityCustomAttributes(List<String> cdTenantIds) {
+    public static Map<String, String> toScalityCustomAttributes(List<String> cdTenantIds) {
         return cdTenantIds.stream()
-                .collect(Collectors.toMap(str-> CD_TENANT_ID_PREFIX + str, str -> ""));
+                .collect(Collectors.toMap(str -> CD_TENANT_ID_PREFIX + str, str -> ""));
     }
 
     /**
      * Converts account ID to Vault super role arn
      *
      * @param accountID account id
-     * @param roleName role name
+     * @param roleName  role name
      * @return the role arn.
-     *          Example: <code>arn:aws:iam::[account-id]:role/[role-name]</code>
+     *         Example: <code>arn:aws:iam::[account-id]:role/[role-name]</code>
      */
     private static String toRoleArn(String accountID, String roleName) {
         return ROLE_ARN_FORMAT
@@ -409,11 +432,13 @@ public final class ScalityModelConverter {
     }
 
     public static String extractCdTenantId(String filter) {
-        return filter.split(FILTER_KEY_VALUE_SEPARATOR) [1];
+        return filter.split(FILTER_KEY_VALUE_SEPARATOR)[1];
     }
 
-    /* Converter methods below will convert Vault/Scality responses to OSIS model objects @param accountResponse the account response */
-
+    /*
+     * Converter methods below will convert Vault/Scality responses to OSIS model
+     * objects @param accountResponse the account response
+     */
 
     /**
      * Converts Vault Create Account response to OSIS Tenant object
@@ -465,12 +490,12 @@ public final class ScalityModelConverter {
         final OsisUser osisUser = new OsisUser();
 
         osisUser.setTenantId(account.getId());
-        if(!account.getCustomAttributes().isEmpty()) {
+        if (!account.getCustomAttributes().isEmpty()) {
             osisUser.setCdTenantId(ScalityModelConverter.toOsisCDTenantIds(account.getCustomAttributes()).get(0));
         }
         osisUser.setCanonicalUserId(account.getCanonicalId());
 
-        if(!users.isEmpty()) {
+        if (!users.isEmpty()) {
             OsisUser user = users.get(users.size() - 1);
             osisUser.setUsername(user.getUsername());
             osisUser.setUserId(user.getUserId());
@@ -487,15 +512,18 @@ public final class ScalityModelConverter {
      * Converts Vault Account customAttributes Map Format to OSIS cdTenantIDs list.
      *
      * @param customAttributes the customAttributes map.
-     *      *          Example: <code>{("cd_tenant_id==9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
+     *                         * Example:
+     *                         <code>{("cd_tenant_id==9b7e3259-aace-414c-bfd8-94daa0efefaf", ""),
      *      *                          ("cd_tenant_id==7b7e3259-aace-414c-bfd8-94daa0efefaf", "")}</code>
-     * @return the cd tenant ids list. Example:<code>["9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf"]</code>
+     * @return the cd tenant ids list.
+     *         Example:<code>["9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf"]</code>
      */
-    public static List<String> toOsisCDTenantIds(Map<String,String> customAttributes) {
-        if(customAttributes==null || customAttributes.size() == 0)
+    public static List<String> toOsisCDTenantIds(Map<String, String> customAttributes) {
+        if (customAttributes == null || customAttributes.size() == 0)
             return new ArrayList<>();
 
-        List<String> cdTenantIds = new ArrayList<String>(customAttributes.keySet()).stream().collect(Collectors.toList());
+        List<String> cdTenantIds = new ArrayList<String>(customAttributes.keySet()).stream()
+                .collect(Collectors.toList());
         cdTenantIds.replaceAll(x -> StringUtils.removeStart(x, CD_TENANT_ID_PREFIX));
         return cdTenantIds;
     }
@@ -508,10 +536,11 @@ public final class ScalityModelConverter {
      * @param limit
      * @return the page of tenants
      */
-    public static PageOfTenants toPageOfTenants(ListAccountsResponseDTO listAccountsResponseDTO, long offset, long limit) {
+    public static PageOfTenants toPageOfTenants(ListAccountsResponseDTO listAccountsResponseDTO, long offset,
+            long limit) {
         List<OsisTenant> tenantItems = new ArrayList<>();
 
-        for(AccountData account: listAccountsResponseDTO.getAccounts()){
+        for (AccountData account : listAccountsResponseDTO.getAccounts()) {
             tenantItems.add(toOsisTenant(account));
         }
 
@@ -549,7 +578,8 @@ public final class ScalityModelConverter {
     /**
      * Converts Vault Generate Account AccessKey response to AWS Credentials
      *
-     * @param generateAccountAccessKeyResponse the Generate Account AccessKey response dto
+     * @param generateAccountAccessKeyResponse the Generate Account AccessKey
+     *                                         response dto
      * @return the AWS credentials for API authentication.
      */
     public static Credentials toCredentials(GenerateAccountAccessKeyResponse generateAccountAccessKeyResponse) {
@@ -578,7 +608,8 @@ public final class ScalityModelConverter {
     }
 
     private static OsisUser.RoleEnum roleFromUserPath(String path) {
-        return path.split("/").length > 2 ? OsisUser.RoleEnum.fromValue(path.split("/")[2]) : OsisUser.RoleEnum.ANONYMOUS;
+        return path.split("/").length > 2 ? OsisUser.RoleEnum.fromValue(path.split("/")[2])
+                : OsisUser.RoleEnum.ANONYMOUS;
     }
 
     private static String emailFromUserPath(String path) {
@@ -593,7 +624,8 @@ public final class ScalityModelConverter {
         return path.split("/").length > 5 ? path.split("/")[5] : userId;
     }
 
-    public static OsisS3Credential toOsisS3Credentials(String cdTenantId, String tenantId, String username, CreateAccessKeyResult createAccessKeyResult) {
+    public static OsisS3Credential toOsisS3Credentials(String cdTenantId, String tenantId, String username,
+            CreateAccessKeyResult createAccessKeyResult) {
         return new OsisS3Credential()
                 .accessKey(createAccessKeyResult.getAccessKey().getAccessKeyId())
                 .secretKey(createAccessKeyResult.getAccessKey().getSecretAccessKey())
@@ -607,7 +639,8 @@ public final class ScalityModelConverter {
                 .immutable(Boolean.TRUE);
     }
 
-    public static OsisS3Credential toOsisS3Credentials(String tenantId, AccessKeyMetadata accessKeyMetadata, String secretKey) {
+    public static OsisS3Credential toOsisS3Credentials(String tenantId, AccessKeyMetadata accessKeyMetadata,
+            String secretKey) {
         OsisS3Credential s3Credential = new OsisS3Credential()
                 .accessKey(accessKeyMetadata.getAccessKeyId())
                 .active(accessKeyMetadata.getStatus()
@@ -633,7 +666,7 @@ public final class ScalityModelConverter {
     public static PageOfUsers toPageOfUsers(ListUsersResult listUsersResult, long offset, long limit, String tenantId) {
         List<OsisUser> userItems = new ArrayList<>();
 
-        for(User user: listUsersResult.getUsers()){
+        for (User user : listUsersResult.getUsers()) {
             userItems.add(toOsisUser(user, tenantId));
         }
 
@@ -678,11 +711,12 @@ public final class ScalityModelConverter {
      * @param secretKeyMap
      * @return the page of users
      */
-    public static PageOfS3Credentials toPageOfS3Credentials(ListAccessKeysResult listAccessKeysResult, long offset, long limit, OsisTenant tenant, Map<String, String> secretKeyMap) {
+    public static PageOfS3Credentials toPageOfS3Credentials(ListAccessKeysResult listAccessKeysResult, long offset,
+            long limit, OsisTenant tenant, Map<String, String> secretKeyMap) {
         List<OsisS3Credential> credentials = new ArrayList<>();
         List<OsisS3Credential> credentialsNoSK = new ArrayList<>();
 
-        for(AccessKeyMetadata accessKeyMetadata: listAccessKeysResult.getAccessKeyMetadata()){
+        for (AccessKeyMetadata accessKeyMetadata : listAccessKeysResult.getAccessKeyMetadata()) {
 
             OsisS3Credential s3Credential = new OsisS3Credential()
                     .accessKey(accessKeyMetadata.getAccessKeyId())
@@ -694,7 +728,7 @@ public final class ScalityModelConverter {
                     .cdTenantId(tenant.getCdTenantIds().get(0))
                     .creationDate(accessKeyMetadata.getCreateDate().toInstant())
                     .immutable(Boolean.TRUE);
-            if(null != secretKeyMap.get(accessKeyMetadata.getAccessKeyId())) {
+            if (null != secretKeyMap.get(accessKeyMetadata.getAccessKeyId())) {
                 // If secret key is available, add credential object to the list
                 s3Credential.setSecretKey(secretKeyMap.get(accessKeyMetadata.getAccessKeyId()));
                 credentials.add(s3Credential);
@@ -705,7 +739,7 @@ public final class ScalityModelConverter {
         }
 
         // Add credential objects with no secret keys to the bottom of the list
-        if(!credentialsNoSK.isEmpty()) {
+        if (!credentialsNoSK.isEmpty()) {
             credentials.addAll(credentialsNoSK);
         }
 
@@ -740,19 +774,21 @@ public final class ScalityModelConverter {
      * @param limit
      * @return the page of s3credentials
      */
-    public static PageOfS3Credentials toPageOfS3Credentials(OsisS3Credential osisS3Credential, String cdTenantId, long offset, long limit) {
+    public static PageOfS3Credentials toPageOfS3Credentials(OsisS3Credential osisS3Credential, String cdTenantId,
+            long offset, long limit) {
 
-        if(osisS3Credential !=null){
+        if (osisS3Credential != null) {
             osisS3Credential.setCdTenantId(cdTenantId);
         }
 
         PageInfo pageInfo = new PageInfo();
         pageInfo.setLimit(limit);
         pageInfo.setOffset(offset);
-        pageInfo.setTotal( (osisS3Credential == null) ? 0 : 1l );
+        pageInfo.setTotal((osisS3Credential == null) ? 0 : 1l);
 
         PageOfS3Credentials pageOfS3Credentials = new PageOfS3Credentials();
-        pageOfS3Credentials.items( (osisS3Credential == null) ? new ArrayList<>() : Collections.singletonList(osisS3Credential));
+        pageOfS3Credentials
+                .items((osisS3Credential == null) ? new ArrayList<>() : Collections.singletonList(osisS3Credential));
         pageOfS3Credentials.setPageInfo(pageInfo);
         return pageOfS3Credentials;
     }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
@@ -11,7 +11,7 @@ import com.scality.osis.security.utils.CipherFactory;
 import com.scality.osis.vaultadmin.impl.VaultAdminImpl;
 import com.scality.osis.vaultadmin.impl.cache.*;
 import com.scality.vaultclient.dto.*;
-import com.vmware.osis.model.OsisUser;
+import com.scality.osis.model.OsisUser;
 import com.scality.osis.resource.ScalityOsisCapsManager;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +32,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class BaseOsisServiceTest {
-    //vault admin mock object
+    // vault admin mock object
     @Mock
     protected static VaultAdminImpl vaultAdminMock;
 
@@ -60,7 +60,7 @@ public class BaseOsisServiceTest {
 
     @BeforeEach
     protected void init() {
-        MockitoAnnotations.initMocks( this );
+        MockitoAnnotations.initMocks(this);
         initMocks();
         scalityOsisServiceUnderTest = new ScalityOsisServiceImpl(appEnvMock, vaultAdminMock, osisCapsManagerMock);
 
@@ -68,12 +68,13 @@ public class BaseOsisServiceTest {
         ReflectionTestUtils.setField(asyncScalityOsisServiceUnderTest, "vaultAdmin", vaultAdminMock);
         ReflectionTestUtils.setField(asyncScalityOsisServiceUnderTest, "appEnv", appEnvMock);
 
-        ReflectionTestUtils.setField(scalityOsisServiceUnderTest, "asyncScalityOsisService", asyncScalityOsisServiceUnderTest);
+        ReflectionTestUtils.setField(scalityOsisServiceUnderTest, "asyncScalityOsisService",
+                asyncScalityOsisServiceUnderTest);
         ReflectionTestUtils.setField(scalityOsisServiceUnderTest, "scalityRedisRepository", redisRepositoryMock);
         ReflectionTestUtils.setField(scalityOsisServiceUnderTest, "cipherFactory", cipherFactoryMock);
     }
 
-    protected void initMocks(){
+    protected void initMocks() {
         when(appEnvMock.getConsoleEndpoint()).thenReturn(TEST_CONSOLE_URL);
         when(appEnvMock.isApiTokenEnabled()).thenReturn(false);
         when(appEnvMock.getStorageInfo()).thenReturn(Collections.singletonList("standard"));
@@ -85,7 +86,7 @@ public class BaseOsisServiceTest {
         when(appEnvMock.getAssumeRoleName()).thenReturn(SAMPLE_ASSUME_ROLE_NAME);
         when(appEnvMock.getSpringCacheType()).thenReturn(REDIS_SPRING_CACHE_TYPE);
         when(osisCapsManagerMock.getNotImplements()).thenReturn(new ArrayList<>());
-        when(vaultAdminMock.getIAMClient(any(Credentials.class),any())).thenReturn(iamMock);
+        when(vaultAdminMock.getIAMClient(any(Credentials.class), any())).thenReturn(iamMock);
 
         initCreateTenantMocks();
         initUpdateTenantMocks();
@@ -114,8 +115,8 @@ public class BaseOsisServiceTest {
 
     private void initBaseCipherMocks() {
         try {
-            when(baseCipherMock.encrypt(any(),any(),any())).thenReturn(mockSecretKeyRepoData());
-            when(baseCipherMock.decrypt(any(),any(),any())).thenReturn(TEST_SECRET_KEY);
+            when(baseCipherMock.encrypt(any(), any(), any())).thenReturn(mockSecretKeyRepoData());
+            when(baseCipherMock.decrypt(any(), any(), any())).thenReturn(TEST_SECRET_KEY);
         } catch (Exception e) {
             init();
         }
@@ -153,16 +154,16 @@ public class BaseOsisServiceTest {
     }
 
     protected void initCreateTenantMocks() {
-        //initialize mock create account response
+        // initialize mock create account response
         when(vaultAdminMock.createAccount(any(CreateAccountRequestDTO.class)))
                 .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
                     final CreateAccountRequestDTO request = invocation.getArgument(0);
                     final AccountData data = new AccountData();
                     data.setEmailAddress(request.getEmailAddress());
                     data.setName(request.getName());
-                    if(StringUtils.isEmpty(request.getExternalAccountId())){
+                    if (StringUtils.isEmpty(request.getExternalAccountId())) {
                         data.setId(SAMPLE_TENANT_ID);
-                    } else{
+                    } else {
                         data.setId(request.getExternalAccountId());
                     }
                     data.setCustomAttributes(request.getCustomAttributes());
@@ -176,7 +177,7 @@ public class BaseOsisServiceTest {
     }
 
     protected void initUpdateTenantMocks() {
-        //initialize mock create account response
+        // initialize mock create account response
         when(vaultAdminMock.updateAccountAttributes(any(UpdateAccountAttributesRequestDTO.class)))
                 .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
                     final UpdateAccountAttributesRequestDTO request = invocation.getArgument(0);
@@ -196,8 +197,8 @@ public class BaseOsisServiceTest {
 
     protected void initListTenantMocks() {
 
-        //initialize mock list accounts response
-        when(vaultAdminMock.listAccounts(anyLong(),any(ListAccountsRequestDTO.class)))
+        // initialize mock list accounts response
+        when(vaultAdminMock.listAccounts(anyLong(), any(ListAccountsRequestDTO.class)))
                 .thenAnswer((Answer<ListAccountsResponseDTO>) invocation -> {
                     final long offset = invocation.getArgument(0);
                     final ListAccountsRequestDTO request = invocation.getArgument(1);
@@ -205,19 +206,21 @@ public class BaseOsisServiceTest {
                     final List<AccountData> accounts = new ArrayList<>();
 
                     // Generate Accounts with ids (markerVal + i) to maxItems count
-                    for( int index = 0; index < maxItems; index++){
+                    for (int index = 0; index < maxItems; index++) {
                         final AccountData data = new AccountData();
                         data.setEmailAddress("xyz@scality.com");
                         data.setName(TEST_NAME);
-                        data.setId(SAMPLE_TENANT_ID + (index + offset)); //setting ID with index
+                        data.setId(SAMPLE_TENANT_ID + (index + offset)); // setting ID with index
 
                         // if filterStartsWith generate customAttributes for all accounts
-                        final Map<String, String> customAttributestemp  = new HashMap<>() ;
+                        final Map<String, String> customAttributestemp = new HashMap<>();
                         data.setCustomAttributes(customAttributestemp);
                         accounts.add(data);
 
-                        if(!StringUtils.isEmpty(request.getFilterKey()) && request.getFilterKey().startsWith(CD_TENANT_ID_PREFIX)) {
-                            // If filter key exists mock only one account in the response with filterKey as customAttributestemp
+                        if (!StringUtils.isEmpty(request.getFilterKey())
+                                && request.getFilterKey().startsWith(CD_TENANT_ID_PREFIX)) {
+                            // If filter key exists mock only one account in the response with filterKey as
+                            // customAttributestemp
                             customAttributestemp.put(request.getFilterKey(), "");
                             break;
                         } else {
@@ -227,14 +230,14 @@ public class BaseOsisServiceTest {
 
                     final ListAccountsResponseDTO response = new ListAccountsResponseDTO();
                     response.setAccounts(accounts);
-                    response.setMarker("M"+(offset+maxItems));
+                    response.setMarker("M" + (offset + maxItems));
                     response.setTruncated(true);
                     return response;
                 });
     }
 
     protected void initTempCredentialsMocks() {
-        //initialize mock vault admin temporary credentials response
+        // initialize mock vault admin temporary credentials response
         when(vaultAdminMock.getTempAccountCredentials(any(AssumeRoleRequest.class)))
                 .thenAnswer((Answer<Credentials>) invocation -> {
                     final Credentials credentials = new Credentials();
@@ -282,7 +285,7 @@ public class BaseOsisServiceTest {
                             .withRoleName(request.getRoleName())
                             .withCreateDate(new Date())
                             .withRoleId(SAMPLE_ID)
-                            .withArn("arn:aws:iam::" + TEST_TENANT_ID +":role/" + request.getRoleName());
+                            .withArn("arn:aws:iam::" + TEST_TENANT_ID + ":role/" + request.getRoleName());
                     response.setRole(role);
                     return response;
                 });
@@ -293,7 +296,7 @@ public class BaseOsisServiceTest {
     }
 
     protected void initDeleteAccessKeyMocks() {
-        when(iamMock.deleteAccessKey(any(DeleteAccessKeyRequest.class))).thenReturn( new DeleteAccessKeyResult());
+        when(iamMock.deleteAccessKey(any(DeleteAccessKeyRequest.class))).thenReturn(new DeleteAccessKeyResult());
     }
 
     protected void initCreatePolicyMocks() {
@@ -304,7 +307,7 @@ public class BaseOsisServiceTest {
                     final Policy policy = new Policy()
                             .withPolicyName(request.getPolicyName())
                             .withDescription(request.getDescription())
-                            .withArn("arn:aws:iam::" + TEST_TENANT_ID +":policy/" + request.getPolicyName());
+                            .withArn("arn:aws:iam::" + TEST_TENANT_ID + ":policy/" + request.getPolicyName());
                     response.setPolicy(policy);
                     return response;
                 });
@@ -315,12 +318,14 @@ public class BaseOsisServiceTest {
                 .thenAnswer((Answer<AccountData>) invocation -> {
 
                     final GetAccountRequestDTO request = invocation.getArgument(0);
-                    final String accountId = request.getAccountId() ==null ? SAMPLE_TENANT_ID : request.getAccountId();
-                    final String accountName = request.getAccountName() ==null ? SAMPLE_TENANT_NAME : request.getAccountName();
+                    final String accountId = request.getAccountId() == null ? SAMPLE_TENANT_ID : request.getAccountId();
+                    final String accountName = request.getAccountName() == null ? SAMPLE_TENANT_NAME
+                            : request.getAccountName();
                     final String accountArn = request.getAccountArn();
-                    final String emailAddress = request.getEmailAddress() ==null ? SAMPLE_SCALITY_ACCOUNT_EMAIL : request.getEmailAddress();
-                    final String canonicalId = request.getCanonicalId() ==null ? SAMPLE_ID : request.getCanonicalId();
-                    final Map<String, String> customAttributestes  = new HashMap<>() ;
+                    final String emailAddress = request.getEmailAddress() == null ? SAMPLE_SCALITY_ACCOUNT_EMAIL
+                            : request.getEmailAddress();
+                    final String canonicalId = request.getCanonicalId() == null ? SAMPLE_ID : request.getCanonicalId();
+                    final Map<String, String> customAttributestes = new HashMap<>();
                     customAttributestes.put(CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID, "");
 
                     final AccountData data = new AccountData();
@@ -407,7 +412,7 @@ public class BaseOsisServiceTest {
 
     protected void initListUserMocks() {
 
-        //initialize mock list accounts response
+        // initialize mock list accounts response
         when(iamMock.listUsers(any(ListUsersRequest.class)))
                 .thenAnswer((Answer<ListUsersResult>) invocation -> listUsersMockResponse(invocation));
     }
@@ -415,25 +420,25 @@ public class BaseOsisServiceTest {
     protected ListUsersResult listUsersMockResponse(final InvocationOnMock invocation) {
         final ListUsersRequest request = invocation.getArgument(0);
         int maxItems = request.getMaxItems();
-        final int markerVal = (request.getMarker() ==null) ? 0 : Integer.parseInt(request.getMarker());
+        final int markerVal = (request.getMarker() == null) ? 0 : Integer.parseInt(request.getMarker());
         final String pathPrefix = request.getPathPrefix();
 
-        if(!StringUtils.isEmpty(pathPrefix)){
+        if (!StringUtils.isEmpty(pathPrefix)) {
             maxItems = 1;
         }
 
         final List<User> users = new ArrayList<>();
 
         // Generate Users with ids (markerVal + i) to maxItems count
-        for( int index = 0; index < maxItems; index++){
-            final String pathFirstSection = StringUtils.isEmpty(pathPrefix) ?
-                    "/"+ TEST_NAME + (index + markerVal) +"/" :
-                    pathPrefix;
+        for (int index = 0; index < maxItems; index++) {
+            final String pathFirstSection = StringUtils.isEmpty(pathPrefix)
+                    ? "/" + TEST_NAME + (index + markerVal) + "/"
+                    : pathPrefix;
 
             final String path = pathFirstSection
-                    + OsisUser.RoleEnum.TENANT_USER.getValue() +"/"
-                    + SAMPLE_SCALITY_USER_EMAIL  + "/"
-                    + TEST_TENANT_ID  + "/";
+                    + OsisUser.RoleEnum.TENANT_USER.getValue() + "/"
+                    + SAMPLE_SCALITY_USER_EMAIL + "/"
+                    + TEST_TENANT_ID + "/";
 
             final User user = new User()
                     .withUserId(TEST_USER_ID + (index + markerVal))
@@ -452,33 +457,33 @@ public class BaseOsisServiceTest {
 
     protected void initGetUserMocks() {
 
-        //initialize mock get user response
+        // initialize mock get user response
         when(iamMock.getUser(any(GetUserRequest.class)))
                 .thenAnswer((Answer<GetUserResult>) invocation -> getUserMockResponse(invocation));
     }
 
     protected void initDeleteUserMocks() {
 
-        //initialize mock get user response
+        // initialize mock get user response
         when(iamMock.deleteUser(any(DeleteUserRequest.class)))
-                .thenAnswer((Answer<DeleteUserResult>) invocation ->  new DeleteUserResult());
+                .thenAnswer((Answer<DeleteUserResult>) invocation -> new DeleteUserResult());
     }
 
     protected void initUpdateAccessKeysMocks() {
 
-        //initialize mock update access keys response
+        // initialize mock update access keys response
         when(iamMock.updateAccessKey(any(UpdateAccessKeyRequest.class)))
-                .thenAnswer((Answer<UpdateAccessKeyResult>) invocation ->  new UpdateAccessKeyResult());
+                .thenAnswer((Answer<UpdateAccessKeyResult>) invocation -> new UpdateAccessKeyResult());
     }
 
     protected GetUserResult getUserMockResponse(final InvocationOnMock invocation) {
         final GetUserRequest request = invocation.getArgument(0);
         final String username = request.getUserName();
 
-        final String path = "/"+ TEST_NAME +"/"
-                + OsisUser.RoleEnum.TENANT_USER.getValue() +"/"
-                + SAMPLE_SCALITY_USER_EMAIL  + "/"
-                + TEST_TENANT_ID  + "/";
+        final String path = "/" + TEST_NAME + "/"
+                + OsisUser.RoleEnum.TENANT_USER.getValue() + "/"
+                + SAMPLE_SCALITY_USER_EMAIL + "/"
+                + TEST_TENANT_ID + "/";
 
         final User user = new User()
                 .withUserId(SAMPLE_ID)
@@ -492,7 +497,8 @@ public class BaseOsisServiceTest {
 
     protected void initCaches() {
         final CacheFactory cacheFactoryMock = mock(CacheFactory.class);
-        when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE)).thenReturn(new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY));
+        when(cacheFactoryMock.getCache(NAME_LIST_ACCOUNTS_CACHE))
+                .thenReturn(new CacheImpl<>(DEFAULT_CACHE_MAX_CAPACITY));
 
         ReflectionTestUtils.setField(vaultAdminMock, "cacheFactory", cacheFactoryMock);
         vaultAdminMock.initCaches();

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceCredentialsTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceCredentialsTests.java
@@ -2,9 +2,9 @@ package com.scality.osis.service.impl;
 
 import com.amazonaws.services.identitymanagement.model.*;
 import com.scality.osis.vaultadmin.impl.VaultServiceException;
-import com.vmware.osis.model.OsisS3Credential;
-import com.vmware.osis.model.PageOfS3Credentials;
-import com.vmware.osis.model.exception.NotImplementedException;
+import com.scality.osis.model.OsisS3Credential;
+import com.scality.osis.model.PageOfS3Credentials;
+import com.scality.osis.model.exception.NotImplementedException;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import org.springframework.http.HttpStatus;
@@ -17,14 +17,15 @@ import static com.scality.osis.utils.ScalityTestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
+public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest {
 
     @Test
     public void testCreateS3Credential() {
         // Setup
 
         // Run the test
-        final OsisS3Credential response = scalityOsisServiceUnderTest.createS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID);
+        final OsisS3Credential response = scalityOsisServiceUnderTest.createS3Credential(SAMPLE_TENANT_ID,
+                TEST_USER_ID);
 
         // Verify the results
         assertNotNull(response.getAccessKey());
@@ -40,12 +41,14 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         // Setup
         when(iamMock.createAccessKey(any(CreateAccessKeyRequest.class)))
                 .thenThrow(
-                        new NoSuchEntityException("The request was rejected because it referenced an entity that does not exist. " +
-                                "The error message describes the entity."));
+                        new NoSuchEntityException(
+                                "The request was rejected because it referenced an entity that does not exist. " +
+                                        "The error message describes the entity."));
 
         // Run the test
         // Verify the results
-        assertThrows(VaultServiceException.class, () -> scalityOsisServiceUnderTest.createS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID));
+        assertThrows(VaultServiceException.class,
+                () -> scalityOsisServiceUnderTest.createS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID));
 
     }
 
@@ -54,14 +57,16 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         // Setup
         when(iamMock.createAccessKey(any(CreateAccessKeyRequest.class)))
                 .thenAnswer((Answer<CreateAccessKeyResult>) invocation -> {
-                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException("Forbidden");
+                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException(
+                            "Forbidden");
                     iamException.setStatusCode(HttpStatus.FORBIDDEN.value());
                     throw iamException;
                 })
                 .thenAnswer((Answer<CreateAccessKeyResult>) invocation -> createAccessKeyMockResponse(invocation));
 
         /// Run the test
-        final OsisS3Credential response = scalityOsisServiceUnderTest.createS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID);
+        final OsisS3Credential response = scalityOsisServiceUnderTest.createS3Credential(SAMPLE_TENANT_ID,
+                TEST_USER_ID);
 
         // Verify the results
         assertNotNull(response.getAccessKey());
@@ -76,13 +81,13 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
     @Test
     public void testQueryS3Credentials() {
         // Setup
-        final String filter = TENANT_ID_PREFIX + TEST_TENANT_ID + FILTER_SEPARATOR + USER_ID_PREFIX + TEST_USER_ID ;
+        final String filter = TENANT_ID_PREFIX + TEST_TENANT_ID + FILTER_SEPARATOR + USER_ID_PREFIX + TEST_USER_ID;
         final long offset = 0L;
         final long limit = 1000L;
 
-
         // Run the test
-        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.queryS3Credentials(offset, limit, filter);
+        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.queryS3Credentials(offset, limit,
+                filter);
 
         // Verify the results
         assertNotNull(pageOfS3Credentials.getItems());
@@ -101,14 +106,14 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         final String filter = TENANT_ID_PREFIX + TEST_TENANT_ID
                 + FILTER_SEPARATOR
                 + USER_ID_PREFIX + TEST_USER_ID
-                +FILTER_SEPARATOR
+                + FILTER_SEPARATOR
                 + OSIS_ACCESS_KEY + FILTER_KEY_VALUE_SEPARATOR + TEST_ACCESS_KEY;
         final long offset = 0L;
         final long limit = 1000L;
 
-
         // Run the test
-        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.queryS3Credentials(offset, limit, filter);
+        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.queryS3Credentials(offset, limit,
+                filter);
 
         // Verify the results
         assertEquals(1, pageOfS3Credentials.getItems().size());
@@ -210,7 +215,8 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         // Setup
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getS3Credential("accessKey"), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getS3Credential("accessKey"),
+                NOT_IMPLEMENTED_EXCEPTION_ERR);
 
         // Verify the results
     }
@@ -220,7 +226,8 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         // Setup
 
         // Run the test
-        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY);
+        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID,
+                TEST_ACCESS_KEY);
 
         // Verify the results
         assertEquals(TEST_USER_ID, result.getCdUserId());
@@ -237,14 +244,16 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         // Setup
         when(iamMock.listAccessKeys(any(ListAccessKeysRequest.class)))
                 .thenAnswer((Answer<ListAccessKeysResult>) invocation -> {
-                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException("Forbidden");
+                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException(
+                            "Forbidden");
                     iamException.setStatusCode(HttpStatus.FORBIDDEN.value());
                     throw iamException;
                 })
                 .thenAnswer((Answer<ListAccessKeysResult>) this::listAccessKeysMockResponse);
 
         // Run the test
-        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY);
+        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID,
+                TEST_ACCESS_KEY);
 
         // Verify the results
         assertEquals(TEST_USER_ID, result.getCdUserId());
@@ -262,7 +271,8 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         when(redisRepositoryMock.hasKey(any())).thenReturn(Boolean.FALSE);
 
         // Run the test
-        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY);
+        final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID,
+                TEST_ACCESS_KEY);
 
         // Verify the results
         assertEquals(TEST_USER_ID, result.getCdUserId());
@@ -279,7 +289,8 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         // Setup
 
         // Run the test
-        assertThrows(VaultServiceException.class, () ->  scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY_2));
+        assertThrows(VaultServiceException.class,
+                () -> scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY_2));
 
         // Verify the results
     }
@@ -289,7 +300,8 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         // Setup
 
         // Run the test
-        assertThrows(VaultServiceException.class, () ->  scalityOsisServiceUnderTest.getS3Credential("", TEST_USER_ID, TEST_ACCESS_KEY_2));
+        assertThrows(VaultServiceException.class,
+                () -> scalityOsisServiceUnderTest.getS3Credential("", TEST_USER_ID, TEST_ACCESS_KEY_2));
 
         // Verify the results
     }
@@ -299,7 +311,8 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         // Setup
 
         // Run the test
-        assertThrows(VaultServiceException.class, () ->  scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, "", TEST_ACCESS_KEY_2));
+        assertThrows(VaultServiceException.class,
+                () -> scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, "", TEST_ACCESS_KEY_2));
 
         // Verify the results
     }
@@ -310,9 +323,9 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         final long offset = 0L;
         final long limit = 1000L;
 
-
         // Run the test
-        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID, TEST_USER_ID, offset, limit);
+        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID,
+                TEST_USER_ID, offset, limit);
 
         // Verify the results
         assertNotNull(pageOfS3Credentials.getItems());
@@ -347,9 +360,9 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         final long offset = 0L;
         final long limit = 1000L;
 
-
         // Run the test
-        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID, TEST_USER_ID, offset, limit);
+        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID,
+                TEST_USER_ID, offset, limit);
 
         // Verify the results
         assertNotNull(pageOfS3Credentials.getItems());
@@ -368,10 +381,11 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         assertEquals(TEST_SECRET_KEY, resultWithSecret.getSecretKey());
 
         // Last entry should have secret key as "Not Available"
-        final OsisS3Credential resultWithNoSecret = pageOfS3Credentials.getItems().get(pageOfS3Credentials.getItems().size()-1);
+        final OsisS3Credential resultWithNoSecret = pageOfS3Credentials.getItems()
+                .get(pageOfS3Credentials.getItems().size() - 1);
 
         assertEquals(TEST_USER_ID, resultWithNoSecret.getCdUserId());
-        assertEquals(TEST_USER_ID , resultWithNoSecret.getUserId());
+        assertEquals(TEST_USER_ID, resultWithNoSecret.getUserId());
         assertEquals(TEST_TENANT_ID, resultWithNoSecret.getTenantId());
         assertEquals(TEST_ACCESS_KEY_2, resultWithNoSecret.getAccessKey());
         assertEquals(NOT_AVAILABLE, resultWithNoSecret.getSecretKey());
@@ -385,11 +399,13 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         final long limit = 1000L;
         when(iamMock.listAccessKeys(any(ListAccessKeysRequest.class)))
                 .thenAnswer((Answer<ListAccessKeysResult>) invocation -> {
-                    throw new NoSuchEntityException("The request was rejected because it referenced an entity that does not exist. The error message describes the entity.");
+                    throw new NoSuchEntityException(
+                            "The request was rejected because it referenced an entity that does not exist. The error message describes the entity.");
                 });
 
         // Run the test
-        final PageOfS3Credentials response = scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID, TEST_USER_ID, offset, limit);
+        final PageOfS3Credentials response = scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID, TEST_USER_ID,
+                offset, limit);
 
         // Verify the results
         assertEquals(0L, response.getPageInfo().getTotal());
@@ -406,14 +422,16 @@ public class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest{
         final long limit = 1000L;
         when(iamMock.listAccessKeys(any(ListAccessKeysRequest.class)))
                 .thenAnswer((Answer<ListAccessKeysResult>) invocation -> {
-                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException("Forbidden");
+                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException(
+                            "Forbidden");
                     iamException.setStatusCode(HttpStatus.FORBIDDEN.value());
                     throw iamException;
                 })
                 .thenAnswer((Answer<ListAccessKeysResult>) invocation -> listAccessKeysMockResponse(invocation));
 
         // Run the test
-        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID, TEST_USER_ID, offset, limit);
+        final PageOfS3Credentials pageOfS3Credentials = scalityOsisServiceUnderTest.listS3Credentials(TEST_TENANT_ID,
+                TEST_USER_ID, offset, limit);
 
         // Verify the results
         assertNotNull(pageOfS3Credentials.getItems());

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -5,10 +5,10 @@ import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.scality.osis.vaultadmin.impl.VaultServiceException;
 import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
-import com.vmware.osis.model.Information;
-import com.vmware.osis.model.OsisCaps;
-import com.vmware.osis.model.OsisS3Credential;
-import com.vmware.osis.model.exception.NotImplementedException;
+import com.scality.osis.model.Information;
+import com.scality.osis.model.ScalityOsisCaps;
+import com.scality.osis.model.OsisS3Credential;
+import com.scality.osis.model.exception.NotImplementedException;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import org.springframework.http.HttpStatus;
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
+public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
 
     @Test
     public void testGetProviderConsoleUrl() {
@@ -68,16 +68,16 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
         final Information information = scalityOsisServiceUnderTest.getInformation(domain);
 
         // Verify the results
-        assertEquals(Information.AuthModesEnum.BASIC, information.getAuthModes().get(0), "Invalid AuthModes" );
-        assertNotNull(information.getStorageClasses(), NULL_ERR );
-        assertNotNull(information.getRegions(), NULL_ERR );
+        assertEquals(Information.AuthModesEnum.BASIC, information.getAuthModes().get(0), "Invalid AuthModes");
+        assertNotNull(information.getStorageClasses(), NULL_ERR);
+        assertNotNull(information.getRegions(), NULL_ERR);
         assertEquals(PLATFORM_NAME, information.getPlatformName(), "Invalid Platform name");
         assertEquals(PLATFORM_VERSION, information.getPlatformVersion(), "Invalid Platform Version");
         assertEquals(API_VERSION, information.getApiVersion(), "Invalid API Version");
         assertEquals(Information.StatusEnum.NORMAL, information.getStatus(), "Invalid status");
         assertEquals(TEST_S3_INTERFACE_URL, information.getServices().getS3(), "Invalid S3 interface URL");
         assertNotNull(information.getNotImplemented(), NULL_ERR);
-        assertEquals(domain + IAM_PREFIX,  information.getServices().getIam(), "Invalid IAM URL");
+        assertEquals(domain + IAM_PREFIX, information.getServices().getIam(), "Invalid IAM URL");
 
     }
 
@@ -91,25 +91,26 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
         final Information information = scalityOsisServiceUnderTest.getInformation(domain);
 
         // Verify the results
-        assertEquals(Information.AuthModesEnum.BEARER, information.getAuthModes().get(0), "Invalid AuthModes" );
-        assertNotNull(information.getStorageClasses(), NULL_ERR );
-        assertNotNull(information.getRegions(), NULL_ERR );
+        assertEquals(Information.AuthModesEnum.BEARER, information.getAuthModes().get(0), "Invalid AuthModes");
+        assertNotNull(information.getStorageClasses(), NULL_ERR);
+        assertNotNull(information.getRegions(), NULL_ERR);
         assertEquals(PLATFORM_NAME, information.getPlatformName(), "Invalid Platform name");
         assertEquals(PLATFORM_VERSION, information.getPlatformVersion(), "Invalid Platform Version");
         assertEquals(API_VERSION, information.getApiVersion(), "Invalid API Version");
         assertEquals(Information.StatusEnum.NORMAL, information.getStatus(), "Invalid status");
         assertEquals(TEST_S3_INTERFACE_URL, information.getServices().getS3(), "Invalid S3 interface URL");
         assertNotNull(information.getNotImplemented(), NULL_ERR);
-        assertEquals(domain + IAM_PREFIX,  information.getServices().getIam(), "Invalid IAM URL");
+        assertEquals(domain + IAM_PREFIX, information.getServices().getIam(), "Invalid IAM URL");
     }
 
     @Test
     public void testUpdateOsisCaps() {
         // Setup
-        final OsisCaps osisCaps = new OsisCaps();
+        final ScalityOsisCaps osisCaps = new ScalityOsisCaps();
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.updateOsisCaps(osisCaps), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.updateOsisCaps(osisCaps),
+                NOT_IMPLEMENTED_EXCEPTION_ERR);
 
         // Verify the results
     }
@@ -119,7 +120,8 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
         // Setup
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getBucketList(TEST_TENANT_ID, 0L, 0L), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        assertThrows(NotImplementedException.class,
+                () -> scalityOsisServiceUnderTest.getBucketList(TEST_TENANT_ID, 0L, 0L), NOT_IMPLEMENTED_EXCEPTION_ERR);
 
         // Verify the results
     }
@@ -217,7 +219,8 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
 
         asyncScalityOsisServiceUnderTest.setupAssumeRole(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME);
 
-        // Verify if all the API calls were skipped after create role if it returns "NoSuchEntity"
+        // Verify if all the API calls were skipped after create role if it returns
+        // "NoSuchEntity"
         verify(vaultAdminMock).getAccountAccessKey(any(GenerateAccountAccessKeyRequest.class));
         verify(iamMock).createRole(any(CreateRoleRequest.class));
         verify(iamMock, never()).createPolicy(any(CreatePolicyRequest.class));
@@ -234,7 +237,8 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
 
         asyncScalityOsisServiceUnderTest.setupAssumeRole(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME);
 
-        // Verify if all the API calls were made successfully even after createPolicy returns "EntityAlreadyExists"
+        // Verify if all the API calls were made successfully even after createPolicy
+        // returns "EntityAlreadyExists"
         verify(vaultAdminMock).getAccountAccessKey(any(GenerateAccountAccessKeyRequest.class));
         verify(iamMock).createRole(any(CreateRoleRequest.class));
         verify(iamMock).createPolicy(any(CreatePolicyRequest.class));
@@ -251,7 +255,8 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
 
         asyncScalityOsisServiceUnderTest.setupAssumeRole(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME);
 
-        // Verify if all the API calls were skipped after attachRolePolicy if it returns "NoSuchEntity"
+        // Verify if all the API calls were skipped after attachRolePolicy if it returns
+        // "NoSuchEntity"
         verify(vaultAdminMock).getAccountAccessKey(any(GenerateAccountAccessKeyRequest.class));
         verify(iamMock).createRole(any(CreateRoleRequest.class));
         verify(iamMock).createPolicy(any(CreatePolicyRequest.class));
@@ -266,7 +271,8 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
         final Policy policy = scalityOsisServiceUnderTest.getOrCreateUserPolicy(iamMock, TEST_TENANT_ID);
 
         // Verify the results
-        assertEquals("arn:aws:iam::" + TEST_TENANT_ID +":policy/userPolicy@" + TEST_TENANT_ID, policy.getArn(), "Invalid Policy arn");
+        assertEquals("arn:aws:iam::" + TEST_TENANT_ID + ":policy/userPolicy@" + TEST_TENANT_ID, policy.getArn(),
+                "Invalid Policy arn");
     }
 
     @Test
@@ -281,7 +287,8 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
         final Policy policy = scalityOsisServiceUnderTest.getOrCreateUserPolicy(iamMock, TEST_TENANT_ID);
 
         // Verify the results
-        assertEquals("arn:aws:iam::" + TEST_TENANT_ID +":policy/userPolicy@" + TEST_TENANT_ID, policy.getArn(), "Invalid Policy arn");
+        assertEquals("arn:aws:iam::" + TEST_TENANT_ID + ":policy/userPolicy@" + TEST_TENANT_ID, policy.getArn(),
+                "Invalid Policy arn");
         assertEquals("userPolicy@" + TEST_TENANT_ID, policy.getPolicyName(), "Invalid Policy name");
     }
 
@@ -291,7 +298,8 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
         // Modify get policy to return no entity found
 
         // Run the test
-        final OsisS3Credential osisCredential = scalityOsisServiceUnderTest.createOsisCredential(TEST_TENANT_ID, TEST_USER_ID, TEST_TENANT_ID, TEST_NAME, iamMock);
+        final OsisS3Credential osisCredential = scalityOsisServiceUnderTest.createOsisCredential(TEST_TENANT_ID,
+                TEST_USER_ID, TEST_TENANT_ID, TEST_NAME, iamMock);
 
         // Verify the results
         assertEquals(TEST_NAME, osisCredential.getUsername(), "Invalid username");
@@ -306,7 +314,8 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
     @Test
     public void testSetupAdminPolicy() throws Exception {
 
-        asyncScalityOsisServiceUnderTest.setupAdminPolicy(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME, SAMPLE_ASSUME_ROLE_NAME);
+        asyncScalityOsisServiceUnderTest.setupAdminPolicy(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME,
+                SAMPLE_ASSUME_ROLE_NAME);
 
         // Verify if all the API calls were made successfully
         verify(vaultAdminMock).getAccountAccessKey(any(GenerateAccountAccessKeyRequest.class));
@@ -322,9 +331,11 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
                     throw new VaultServiceException(HttpStatus.CONFLICT, "EntityAlreadyExists");
                 });
 
-        asyncScalityOsisServiceUnderTest.setupAdminPolicy(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME, SAMPLE_ASSUME_ROLE_NAME);
+        asyncScalityOsisServiceUnderTest.setupAdminPolicy(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME,
+                SAMPLE_ASSUME_ROLE_NAME);
 
-        // Verify if all the API calls were made successfully even after createPolicy returns "EntityAlreadyExists"
+        // Verify if all the API calls were made successfully even after createPolicy
+        // returns "EntityAlreadyExists"
         verify(vaultAdminMock).getAccountAccessKey(any(GenerateAccountAccessKeyRequest.class));
         verify(iamMock).createPolicy(any(CreatePolicyRequest.class));
         verify(iamMock).attachRolePolicy(any(AttachRolePolicyRequest.class));
@@ -338,14 +349,15 @@ public class ScalityOsisServiceMiscTests extends BaseOsisServiceTest{
                     throw new VaultServiceException(HttpStatus.NOT_FOUND, "NoSuchEntity");
                 });
 
-        assertThrows(VaultServiceException.class, () -> asyncScalityOsisServiceUnderTest.setupAdminPolicy(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME, SAMPLE_ASSUME_ROLE_NAME));
+        assertThrows(VaultServiceException.class, () -> asyncScalityOsisServiceUnderTest
+                .setupAdminPolicy(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME, SAMPLE_ASSUME_ROLE_NAME));
 
-        // Verify if all the API calls were skipped after attachRolePolicy if it returns "NoSuchEntity"
+        // Verify if all the API calls were skipped after attachRolePolicy if it returns
+        // "NoSuchEntity"
         verify(vaultAdminMock).getAccountAccessKey(any(GenerateAccountAccessKeyRequest.class));
         verify(iamMock).createPolicy(any(CreatePolicyRequest.class));
         verify(iamMock).attachRolePolicy(any(AttachRolePolicyRequest.class));
         verify(iamMock, never()).deleteAccessKey(any(DeleteAccessKeyRequest.class));
     }
-
 
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
@@ -6,10 +6,10 @@ import com.scality.vaultclient.dto.CreateAccountResponseDTO;
 import com.scality.vaultclient.dto.GetAccountRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsRequestDTO;
 import com.scality.vaultclient.dto.ListAccountsResponseDTO;
-import com.vmware.osis.model.OsisTenant;
-import com.vmware.osis.model.PageOfTenants;
-import com.vmware.osis.model.exception.BadRequestException;
-import com.vmware.osis.model.exception.NotImplementedException;
+import com.scality.osis.model.OsisTenant;
+import com.scality.osis.model.PageOfTenants;
+import com.scality.osis.model.exception.BadRequestException;
+import com.scality.osis.model.exception.NotImplementedException;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import org.springframework.http.HttpStatus;
@@ -24,10 +24,10 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.when;
 
-public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
+public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
 
     @Test
-    public void testCreateTenant(){
+    public void testCreateTenant() {
 
         // Call Scality Osis service to create a tenant
         final OsisTenant osisTenantRes = scalityOsisServiceUnderTest.createTenant(createSampleOsisTenantObj());
@@ -35,12 +35,13 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         assertEquals(SAMPLE_ID, osisTenantRes.getTenantId());
         assertEquals(SAMPLE_TENANT_NAME, osisTenantRes.getName());
         assertTrue(SAMPLE_CD_TENANT_IDS.size() == osisTenantRes.getCdTenantIds().size() &&
-                SAMPLE_CD_TENANT_IDS.containsAll(osisTenantRes.getCdTenantIds()) && osisTenantRes.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS));
+                SAMPLE_CD_TENANT_IDS.containsAll(osisTenantRes.getCdTenantIds())
+                && osisTenantRes.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS));
         assertTrue(osisTenantRes.getActive());
     }
 
     @Test
-    public void testCreateTenantInactive(){
+    public void testCreateTenantInactive() {
         final OsisTenant osisTenantReq = createSampleOsisTenantObj();
         osisTenantReq.active(false);
 
@@ -65,7 +66,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
     }
 
     @Test
-    public void testCreateTenant400(){
+    public void testCreateTenant400() {
 
         when(vaultAdminMock.createAccount(any(CreateAccountRequestDTO.class)))
                 .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
@@ -91,7 +92,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         assertEquals(limit, response.getPageInfo().getTotal());
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
-        assertEquals((int)limit, response.getItems().size());
+        assertEquals((int) limit, response.getItems().size());
         assertNotNull(response.getItems().get(0).getCdTenantIds());
     }
 
@@ -104,12 +105,11 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         // Call Scality Osis service to list tenants
         final PageOfTenants response = scalityOsisServiceUnderTest.listTenants(offset, limit);
 
-
         // Verify the results
         assertEquals(limit, response.getPageInfo().getTotal());
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
-        assertEquals((int)limit, response.getItems().size());
+        assertEquals((int) limit, response.getItems().size());
         assertNotNull(response.getItems().get(0).getCdTenantIds());
     }
 
@@ -118,9 +118,10 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        when(vaultAdminMock.listAccounts(anyLong(),any(ListAccountsRequestDTO.class)))
+        when(vaultAdminMock.listAccounts(anyLong(), any(ListAccountsRequestDTO.class)))
                 .thenAnswer((Answer<ListAccountsResponseDTO>) invocation -> {
-                    throw new VaultServiceException(HttpStatus.BAD_REQUEST, "Requested offset is outside the total available items");
+                    throw new VaultServiceException(HttpStatus.BAD_REQUEST,
+                            "Requested offset is outside the total available items");
                 });
 
         final PageOfTenants response = scalityOsisServiceUnderTest.listTenants(offset, limit);
@@ -181,7 +182,6 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         // Call Scality Osis service to list tenants
         final PageOfTenants response = scalityOsisServiceUnderTest.queryTenants(offset, limit, filter);
 
-
         // Verify the results
         assertEquals(1, response.getPageInfo().getTotal());
         assertEquals(offset, response.getPageInfo().getOffset());
@@ -205,7 +205,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         assertEquals(limit, response.getPageInfo().getTotal());
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
-        assertEquals((int)limit, response.getItems().size());
+        assertEquals((int) limit, response.getItems().size());
         assertNotNull(response.getItems().get(0).getCdTenantIds());
     }
 
@@ -216,9 +216,10 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         final long limit = 1000L;
         final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID;
 
-        when(vaultAdminMock.listAccounts(anyLong(),any(ListAccountsRequestDTO.class)))
+        when(vaultAdminMock.listAccounts(anyLong(), any(ListAccountsRequestDTO.class)))
                 .thenAnswer((Answer<ListAccountsResponseDTO>) invocation -> {
-                    throw new VaultServiceException(HttpStatus.BAD_REQUEST, "Requested offset is outside the total available items");
+                    throw new VaultServiceException(HttpStatus.BAD_REQUEST,
+                            "Requested offset is outside the total available items");
                 });
 
         final PageOfTenants response = scalityOsisServiceUnderTest.queryTenants(offset, limit, filter);
@@ -236,7 +237,8 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         // Setup
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.deleteTenant(TEST_TENANT_ID, false), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        assertThrows(NotImplementedException.class,
+                () -> scalityOsisServiceUnderTest.deleteTenant(TEST_TENANT_ID, false), NOT_IMPLEMENTED_EXCEPTION_ERR);
 
         // Verify the results
     }
@@ -245,12 +247,14 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
     public void testUpdateTenant() {
 
         // Call Scality Osis service to update a tenant
-        final OsisTenant osisTenantRes = scalityOsisServiceUnderTest.updateTenant(SAMPLE_ID, createSampleOsisTenantObj());
+        final OsisTenant osisTenantRes = scalityOsisServiceUnderTest.updateTenant(SAMPLE_ID,
+                createSampleOsisTenantObj());
 
         assertEquals(SAMPLE_ID, osisTenantRes.getTenantId());
         assertEquals(SAMPLE_TENANT_NAME, osisTenantRes.getName());
         assertTrue(SAMPLE_CD_TENANT_IDS.size() == osisTenantRes.getCdTenantIds().size() &&
-                SAMPLE_CD_TENANT_IDS.containsAll(osisTenantRes.getCdTenantIds()) && osisTenantRes.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS));
+                SAMPLE_CD_TENANT_IDS.containsAll(osisTenantRes.getCdTenantIds())
+                && osisTenantRes.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS));
         assertTrue(osisTenantRes.getActive());
     }
 
@@ -269,7 +273,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
     }
 
     @Test
-    public void testUpdateTenantInactive(){
+    public void testUpdateTenantInactive() {
         final OsisTenant osisTenantReq = createSampleOsisTenantObj();
         osisTenantReq.active(false);
 
@@ -280,7 +284,7 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
     }
 
     @Test
-    public void testUpdateTenant400(){
+    public void testUpdateTenant400() {
 
         when(vaultAdminMock.updateAccountAttributes(any()))
                 .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
@@ -306,7 +310,8 @@ public class ScalityOsisServiceTenantTests extends BaseOsisServiceTest{
         expectedResult.setCdTenantIds(Arrays.asList(TEST_STR));
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getTenant(TEST_TENANT_ID), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.getTenant(TEST_TENANT_ID),
+                NOT_IMPLEMENTED_EXCEPTION_ERR);
 
         // Verify the results
     }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
@@ -1,8 +1,8 @@
 package com.scality.osis.service.impl;
 
 import com.amazonaws.services.identitymanagement.model.*;
-import com.vmware.osis.model.*;
-import com.vmware.osis.model.exception.*;
+import com.scality.osis.model.*;
+import com.scality.osis.model.exception.*;
 import com.scality.vaultclient.dto.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -16,7 +16,7 @@ import static com.scality.osis.utils.ScalityTestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
+public class ScalityOsisServiceUserTests extends BaseOsisServiceTest {
 
     @Test
     public void testCreateUser() {
@@ -40,13 +40,20 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         assertEquals(TEST_NAME, result.getUsername());
         assertEquals(TEST_TENANT_ID, result.getCdTenantId());
         assertEquals(TEST_TENANT_ID, result.getTenantId());
-        assertEquals(TEST_NAME, result.getOsisS3Credentials().get(0).getUsername(), "Invalid getOsisS3Credentials username");
-        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getUserId(), "Invalid getOsisS3Credentials getUserId");
-        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getCdUserId(), "Invalid getOsisS3Credentials getCdUserId");
-        assertEquals(TEST_SECRET_KEY, result.getOsisS3Credentials().get(0).getSecretKey(), "Invalid getOsisS3Credentials getSecretKey");
-        assertEquals(TEST_ACCESS_KEY, result.getOsisS3Credentials().get(0).getAccessKey(), "Invalid getOsisS3Credentials getAccessKey");
-        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getTenantId(), "Invalid getOsisS3Credentials getTenantId");
-        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getCdTenantId(), "Invalid getOsisS3Credentials getCdTenantId");
+        assertEquals(TEST_NAME, result.getOsisS3Credentials().get(0).getUsername(),
+                "Invalid getOsisS3Credentials username");
+        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getUserId(),
+                "Invalid getOsisS3Credentials getUserId");
+        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getCdUserId(),
+                "Invalid getOsisS3Credentials getCdUserId");
+        assertEquals(TEST_SECRET_KEY, result.getOsisS3Credentials().get(0).getSecretKey(),
+                "Invalid getOsisS3Credentials getSecretKey");
+        assertEquals(TEST_ACCESS_KEY, result.getOsisS3Credentials().get(0).getAccessKey(),
+                "Invalid getOsisS3Credentials getAccessKey");
+        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getTenantId(),
+                "Invalid getOsisS3Credentials getTenantId");
+        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getCdTenantId(),
+                "Invalid getOsisS3Credentials getCdTenantId");
         assertTrue(result.getActive());
     }
 
@@ -80,7 +87,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
 
         when(iamMock.createUser(any(CreateUserRequest.class)))
                 .thenAnswer((Answer<CreateUserResult>) invocation -> {
-                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException("Forbidden");
+                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException(
+                            "Forbidden");
                     iamException.setStatusCode(HttpStatus.FORBIDDEN.value());
                     throw iamException;
                 })
@@ -95,13 +103,20 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         assertEquals(TEST_NAME, result.getUsername());
         assertEquals(TEST_TENANT_ID, result.getCdTenantId());
         assertEquals(TEST_TENANT_ID, result.getTenantId());
-        assertEquals(TEST_NAME, result.getOsisS3Credentials().get(0).getUsername(), "Invalid getOsisS3Credentials username");
-        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getUserId(), "Invalid getOsisS3Credentials getUserId");
-        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getCdUserId(), "Invalid getOsisS3Credentials getCdUserId");
-        assertEquals(TEST_SECRET_KEY, result.getOsisS3Credentials().get(0).getSecretKey(), "Invalid getOsisS3Credentials getSecretKey");
-        assertEquals(TEST_ACCESS_KEY, result.getOsisS3Credentials().get(0).getAccessKey(), "Invalid getOsisS3Credentials getAccessKey");
-        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getTenantId(), "Invalid getOsisS3Credentials getTenantId");
-        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getCdTenantId(), "Invalid getOsisS3Credentials getCdTenantId");
+        assertEquals(TEST_NAME, result.getOsisS3Credentials().get(0).getUsername(),
+                "Invalid getOsisS3Credentials username");
+        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getUserId(),
+                "Invalid getOsisS3Credentials getUserId");
+        assertEquals(TEST_USER_ID, result.getOsisS3Credentials().get(0).getCdUserId(),
+                "Invalid getOsisS3Credentials getCdUserId");
+        assertEquals(TEST_SECRET_KEY, result.getOsisS3Credentials().get(0).getSecretKey(),
+                "Invalid getOsisS3Credentials getSecretKey");
+        assertEquals(TEST_ACCESS_KEY, result.getOsisS3Credentials().get(0).getAccessKey(),
+                "Invalid getOsisS3Credentials getAccessKey");
+        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getTenantId(),
+                "Invalid getOsisS3Credentials getTenantId");
+        assertEquals(TEST_TENANT_ID, result.getOsisS3Credentials().get(0).getCdTenantId(),
+                "Invalid getOsisS3Credentials getCdTenantId");
         assertTrue(result.getActive());
     }
 
@@ -110,7 +125,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX + TEST_NAME;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX
+                + TEST_NAME;
         // cd_tenant_id==e7ecb16e-f6b7-4d34-ad4e-5da5d5c8317;display_name%3D%3D==name
 
         when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
@@ -132,7 +148,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter =  DISPLAY_NAME_PREFIX + TEST_NAME + FILTER_SEPARATOR +  CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID;
+        final String filter = DISPLAY_NAME_PREFIX + TEST_NAME + FILTER_SEPARATOR + CD_TENANT_ID_PREFIX
+                + SAMPLE_CD_TENANT_ID;
 
         when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
 
@@ -153,12 +170,13 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = TENANT_ID_PREFIX + SAMPLE_TENANT_ID + FILTER_SEPARATOR + CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX + TEST_NAME;
+        final String filter = TENANT_ID_PREFIX + SAMPLE_TENANT_ID + FILTER_SEPARATOR + CD_TENANT_ID_PREFIX
+                + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX + TEST_NAME;
 
         // Run the test
         final PageOfUsers response = scalityOsisServiceUnderTest.queryUsers(offset, limit, filter);
 
-        //verify getAccount never called as tenantID is present
+        // verify getAccount never called as tenantID is present
         verify(vaultAdminMock, never()).getAccountID(any());
 
         // Verify the results
@@ -175,7 +193,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + USERNAME_PREFIX + TEST_NAME;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + USERNAME_PREFIX
+                + TEST_NAME;
 
         when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
 
@@ -196,7 +215,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + USER_ID_PREFIX + TEST_USER_ID;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + USER_ID_PREFIX
+                + TEST_USER_ID;
 
         when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
 
@@ -217,7 +237,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + CD_USER_ID_PREFIX + TEST_USER_ID;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + CD_USER_ID_PREFIX
+                + TEST_USER_ID;
 
         when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
 
@@ -238,7 +259,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX + TEST_NAME;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX
+                + TEST_NAME;
         // cd_tenant_id==e7ecb16e-f6b7-4d34-ad4e-5da5d5c8317;display_name%3D%3D==name
 
         // Run the test
@@ -258,7 +280,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX + TEST_NAME;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX
+                + TEST_NAME;
         // cd_tenant_id==e7ecb16e-f6b7-4d34-ad4e-5da5d5c8317;display_name%3D%3D==name
 
         when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenThrow(
@@ -279,7 +302,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         final long offset = 0L;
         final long limit = 1000L;
-        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX + TEST_NAME;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX
+                + TEST_NAME;
         // cd_tenant_id==e7ecb16e-f6b7-4d34-ad4e-5da5d5c8317;display_name%3D%3D==name
 
         when(vaultAdminMock.getAccountID(any(ListAccountsRequestDTO.class))).thenReturn(SAMPLE_TENANT_ID);
@@ -321,7 +345,7 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Verify the results
         verify(iamMock).detachUserPolicy(any(DetachUserPolicyRequest.class));
 
-        //verify if delete user is not called if detach user policy failed
+        // verify if delete user is not called if detach user policy failed
         verify(iamMock, never()).deleteUser(any(DeleteUserRequest.class));
     }
 
@@ -411,7 +435,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
 
         // Run the test
         // Verify the results
-        assertThrows(VaultServiceException.class, () -> scalityOsisServiceUnderTest.getUser(TEST_TENANT_ID, TEST_USER_ID));
+        assertThrows(VaultServiceException.class,
+                () -> scalityOsisServiceUnderTest.getUser(TEST_TENANT_ID, TEST_USER_ID));
     }
 
     @Test
@@ -420,12 +445,14 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         when(iamMock.getUser(any(GetUserRequest.class)))
                 .thenAnswer((Answer<GetUserResult>) invocation -> {
                     final GetUserRequest request = invocation.getArgument(0);
-                    throw new NoSuchEntityException("The user with name " + request.getUserName() +" cannot be found.");
+                    throw new NoSuchEntityException(
+                            "The user with name " + request.getUserName() + " cannot be found.");
                 });
 
         // Run the test
         // Verify the results
-        assertThrows(VaultServiceException.class, () -> scalityOsisServiceUnderTest.getUser(TEST_TENANT_ID, TEST_USER_ID));
+        assertThrows(VaultServiceException.class,
+                () -> scalityOsisServiceUnderTest.getUser(TEST_TENANT_ID, TEST_USER_ID));
     }
 
     @Test
@@ -433,7 +460,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
         when(iamMock.getUser(any(GetUserRequest.class)))
                 .thenAnswer((Answer<GetUserResult>) invocation -> {
-                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException("Forbidden");
+                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException(
+                            "Forbidden");
                     iamException.setStatusCode(HttpStatus.FORBIDDEN.value());
                     throw iamException;
                 })
@@ -483,7 +511,9 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Setup
 
         // Run the test
-        assertThrows(NotImplementedException.class, () -> scalityOsisServiceUnderTest.headUser(TEST_TENANT_ID, TEST_USER_ID), NOT_IMPLEMENTED_EXCEPTION_ERR);
+        assertThrows(NotImplementedException.class,
+                () -> scalityOsisServiceUnderTest.headUser(TEST_TENANT_ID, TEST_USER_ID),
+                NOT_IMPLEMENTED_EXCEPTION_ERR);
 
         // Verify the results
 
@@ -502,7 +532,7 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         assertEquals(limit, response.getPageInfo().getTotal());
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
-        assertEquals((int)limit, response.getItems().size());
+        assertEquals((int) limit, response.getItems().size());
     }
 
     @Test
@@ -518,7 +548,7 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         assertEquals(limit, response.getPageInfo().getTotal());
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
-        assertEquals((int)limit, response.getItems().size());
+        assertEquals((int) limit, response.getItems().size());
     }
 
     @Test
@@ -528,7 +558,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         final long limit = 1000L;
         when(iamMock.listUsers(any(ListUsersRequest.class)))
                 .thenAnswer((Answer<ListUsersResult>) invocation -> {
-                    throw new VaultServiceException(HttpStatus.BAD_REQUEST, "Requested offset is outside the total available items");
+                    throw new VaultServiceException(HttpStatus.BAD_REQUEST,
+                            "Requested offset is outside the total available items");
                 });
 
         // Run the test
@@ -550,7 +581,8 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
 
         when(iamMock.listUsers(any(ListUsersRequest.class)))
                 .thenAnswer((Answer<ListUsersResult>) invocation -> {
-                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException("Forbidden");
+                    final AmazonIdentityManagementException iamException = new AmazonIdentityManagementException(
+                            "Forbidden");
                     iamException.setStatusCode(HttpStatus.FORBIDDEN.value());
                     throw iamException;
                 })
@@ -563,7 +595,7 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         assertEquals(limit, response.getPageInfo().getTotal());
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
-        assertEquals((int)limit, response.getItems().size());
+        assertEquals((int) limit, response.getItems().size());
 
     }
 
@@ -594,7 +626,7 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         assertEquals(limit, response.getPageInfo().getTotal());
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
-        assertEquals((int)limit, response.getItems().size());
+        assertEquals((int) limit, response.getItems().size());
         // Assert if at least one user is inactive
         assertFalse(response.getItems().get(0).getActive());
     }
@@ -638,6 +670,5 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest{
         // Verify the results
         assertTrue(resUser.getActive());
     }
-
 
 }

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -3,8 +3,8 @@ package com.scality.osis.utils;
 import com.amazonaws.services.identitymanagement.model.*;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
-import com.vmware.osis.model.*;
-import com.vmware.osis.model.exception.BadRequestException;
+import com.scality.osis.model.*;
+import com.scality.osis.model.exception.BadRequestException;
 import com.scality.vaultclient.dto.*;
 import org.junit.jupiter.api.Test;
 
@@ -25,24 +25,24 @@ import static com.scality.osis.utils.ScalityTestUtils.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-
 public class ScalityModelConverterTest {
 
     @Test
-    public void testToScalityAccountEmailTest(){
+    public void testToScalityAccountEmailTest() {
         assertEquals(SAMPLE_SCALITY_ACCOUNT_EMAIL,
-                ScalityModelConverter.generateTenantEmail(SAMPLE_TENANT_NAME),"failed generateTenantEmail");
+                ScalityModelConverter.generateTenantEmail(SAMPLE_TENANT_NAME), "failed generateTenantEmail");
     }
 
     @Test
-    public void testToOsisCDTenantIdsTest(){
+    public void testToOsisCDTenantIdsTest() {
         final List<String> result = ScalityModelConverter.toOsisCDTenantIds(SAMPLE_CUSTOM_ATTRIBUTES);
         assertTrue(SAMPLE_CD_TENANT_IDS.size() == result.size() &&
-                SAMPLE_CD_TENANT_IDS.containsAll(result) && result.containsAll(SAMPLE_CD_TENANT_IDS), "failed toOsisCDTenantIdsTest");
+                SAMPLE_CD_TENANT_IDS.containsAll(result) && result.containsAll(SAMPLE_CD_TENANT_IDS),
+                "failed toOsisCDTenantIdsTest");
     }
 
     @Test
-    public void  testToScalityCreateAccountRequestTest() throws Exception {
+    public void testToScalityCreateAccountRequestTest() throws Exception {
 
         final OsisTenant osisTenant = new OsisTenant();
         osisTenant.tenantId(SAMPLE_TENANT_ID);
@@ -50,15 +50,19 @@ public class ScalityModelConverterTest {
         osisTenant.cdTenantIds(SAMPLE_CD_TENANT_IDS);
         osisTenant.active(true);
 
-        final CreateAccountRequestDTO createAccountRequestDTO = ScalityModelConverter.toScalityCreateAccountRequest(osisTenant);
+        final CreateAccountRequestDTO createAccountRequestDTO = ScalityModelConverter
+                .toScalityCreateAccountRequest(osisTenant);
 
-        assertEquals(SAMPLE_SCALITY_ACCOUNT_EMAIL, createAccountRequestDTO.getEmailAddress(), "failed  toScalityCreateAccountRequestTest:getEmailAddress()");
-        assertEquals(SAMPLE_TENANT_NAME, createAccountRequestDTO.getName(), "failed  toScalityCreateAccountRequestTest:getName()");
-        assertEquals(SAMPLE_TENANT_ID, createAccountRequestDTO.getExternalAccountId(), "failed  toScalityCreateAccountRequestTest:getExternalAccountId()");
+        assertEquals(SAMPLE_SCALITY_ACCOUNT_EMAIL, createAccountRequestDTO.getEmailAddress(),
+                "failed  toScalityCreateAccountRequestTest:getEmailAddress()");
+        assertEquals(SAMPLE_TENANT_NAME, createAccountRequestDTO.getName(),
+                "failed  toScalityCreateAccountRequestTest:getName()");
+        assertEquals(SAMPLE_TENANT_ID, createAccountRequestDTO.getExternalAccountId(),
+                "failed  toScalityCreateAccountRequestTest:getExternalAccountId()");
     }
 
     @Test
-    public void  testToScalityCreateAccountRequestNullTenantId() {
+    public void testToScalityCreateAccountRequestNullTenantId() {
 
         final OsisTenant osisTenant = new OsisTenant();
         osisTenant.tenantId(null);
@@ -66,13 +70,15 @@ public class ScalityModelConverterTest {
         osisTenant.cdTenantIds(SAMPLE_CD_TENANT_IDS);
         osisTenant.active(true);
 
-        final CreateAccountRequestDTO createAccountRequestDTO = ScalityModelConverter.toScalityCreateAccountRequest(osisTenant);
+        final CreateAccountRequestDTO createAccountRequestDTO = ScalityModelConverter
+                .toScalityCreateAccountRequest(osisTenant);
 
-        assertNull(createAccountRequestDTO.getExternalAccountId(), "toScalityCreateAccountRequestTest should throw Null Pointer :getExternalAccountId()");
+        assertNull(createAccountRequestDTO.getExternalAccountId(),
+                "toScalityCreateAccountRequestTest should throw Null Pointer :getExternalAccountId()");
     }
 
     @Test
-    public void  testToScalityCreateAccountRequestActiveErr(){
+    public void testToScalityCreateAccountRequestActiveErr() {
         final OsisTenant osisTenant = new OsisTenant();
         osisTenant.active(false);
         assertThrows(BadRequestException.class, () -> {
@@ -90,34 +96,40 @@ public class ScalityModelConverterTest {
         data.setCustomAttributes(SAMPLE_CUSTOM_ATTRIBUTES);
         final Account account = new Account();
         account.setData(data);
-        final CreateAccountResponseDTO responseDTO = new CreateAccountResponseDTO ();
+        final CreateAccountResponseDTO responseDTO = new CreateAccountResponseDTO();
         responseDTO.setAccount(account);
 
-        //vault specific email address format for ose-scality
+        // vault specific email address format for ose-scality
         final OsisTenant osisTenant = ScalityModelConverter.toOsisTenant(responseDTO);
-        assertEquals(SAMPLE_TENANT_ID, osisTenant.getTenantId(), "failed createAccountResponseToOsisTenantTest:getTenantId()");
-        assertEquals(SAMPLE_TENANT_NAME, osisTenant.getName(), "failed createAccountResponseToOsisTenantTest:getName()");
+        assertEquals(SAMPLE_TENANT_ID, osisTenant.getTenantId(),
+                "failed createAccountResponseToOsisTenantTest:getTenantId()");
+        assertEquals(SAMPLE_TENANT_NAME, osisTenant.getName(),
+                "failed createAccountResponseToOsisTenantTest:getName()");
         assertTrue(SAMPLE_CD_TENANT_IDS.size() == osisTenant.getCdTenantIds().size() &&
                 SAMPLE_CD_TENANT_IDS.containsAll(osisTenant.getCdTenantIds())
-                && osisTenant.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS), "failed createAccountResponseToOsisTenantTest:getCdTenantIds()");
+                && osisTenant.getCdTenantIds().containsAll(SAMPLE_CD_TENANT_IDS),
+                "failed createAccountResponseToOsisTenantTest:getCdTenantIds()");
         assertTrue(osisTenant.getActive(), "failed createAccountResponseToOsisTenantTest:getActive()");
     }
 
     @Test
-    public void  testGetAssumeRoleRequestForAccount() {
+    public void testGetAssumeRoleRequestForAccount() {
 
+        final AssumeRoleRequest assumeRoleRequest = ScalityModelConverter
+                .getAssumeRoleRequestForAccount(SAMPLE_TENANT_ID, SAMPLE_ASSUME_ROLE_NAME);
 
-        final AssumeRoleRequest assumeRoleRequest = ScalityModelConverter.getAssumeRoleRequestForAccount(SAMPLE_TENANT_ID, SAMPLE_ASSUME_ROLE_NAME);
-
-        assertEquals(TEST_ROLE_ARN, assumeRoleRequest.getRoleArn(), "failed  testGetAssumeRoleRequestForAccount:getRoleArn()");
-        assertTrue(assumeRoleRequest.getRoleSessionName().startsWith(TEST_SESSION_NAME_PREFIX), "failed  testGetAssumeRoleRequestForAccount:getRoleSessionName()");
+        assertEquals(TEST_ROLE_ARN, assumeRoleRequest.getRoleArn(),
+                "failed  testGetAssumeRoleRequestForAccount:getRoleArn()");
+        assertTrue(assumeRoleRequest.getRoleSessionName().startsWith(TEST_SESSION_NAME_PREFIX),
+                "failed  testGetAssumeRoleRequestForAccount:getRoleSessionName()");
     }
 
     @Test
     public void testToGenerateAccountAccessKeyRequest() {
         // Setup
         // Run the test
-        final GenerateAccountAccessKeyRequest result = ScalityModelConverter.toGenerateAccountAccessKeyRequest(SAMPLE_TENANT_NAME, SAMPLE_DURATION_SECONDS);
+        final GenerateAccountAccessKeyRequest result = ScalityModelConverter
+                .toGenerateAccountAccessKeyRequest(SAMPLE_TENANT_NAME, SAMPLE_DURATION_SECONDS);
 
         // Verify the results
         assertEquals(SAMPLE_TENANT_NAME, result.getAccountName());
@@ -151,7 +163,8 @@ public class ScalityModelConverterTest {
     public void testToAttachAdminPolicyRequest() {
         // Setup
         // Run the test
-        final AttachRolePolicyRequest result = ScalityModelConverter.toAttachAdminPolicyRequest(TEST_POLICY_ARN, TEST_NAME);
+        final AttachRolePolicyRequest result = ScalityModelConverter.toAttachAdminPolicyRequest(TEST_POLICY_ARN,
+                TEST_NAME);
 
         // Verify the results
         assertEquals(TEST_NAME, result.getRoleName());
@@ -162,7 +175,8 @@ public class ScalityModelConverterTest {
     public void testToDeleteAccessKeyRequest() {
         // Setup
         // Run the test
-        final DeleteAccessKeyRequest result = ScalityModelConverter.toDeleteAccessKeyRequest(TEST_ACCESS_KEY, TEST_NAME);
+        final DeleteAccessKeyRequest result = ScalityModelConverter.toDeleteAccessKeyRequest(TEST_ACCESS_KEY,
+                TEST_NAME);
 
         // Verify the results
         assertEquals(TEST_NAME, result.getUserName());
@@ -236,7 +250,7 @@ public class ScalityModelConverterTest {
     }
 
     @Test
-    public void  testToCreateUserRequest() {
+    public void testToCreateUserRequest() {
         final OsisUser osisUser = new OsisUser();
         osisUser.setCanonicalUserId(TEST_CANONICAL_ID);
         osisUser.setTenantId(TEST_TENANT_ID);
@@ -247,7 +261,7 @@ public class ScalityModelConverterTest {
         osisUser.setEmail(SAMPLE_SCALITY_USER_EMAIL);
         osisUser.setCdTenantId(TEST_TENANT_ID);
 
-        final CreateUserRequest createUserRequest =  ScalityModelConverter.toCreateUserRequest(osisUser);
+        final CreateUserRequest createUserRequest = ScalityModelConverter.toCreateUserRequest(osisUser);
 
         assertEquals(TEST_USER_ID, createUserRequest.getUserName());
         assertTrue(createUserRequest.getPath().contains(TEST_NAME));
@@ -273,7 +287,7 @@ public class ScalityModelConverterTest {
     public void testToGetPolicyRequest() {
         // Setup
         final GetPolicyRequest expectedResult = new GetPolicyRequest();
-        expectedResult.setPolicyArn("arn:aws:iam::" + TEST_TENANT_ID +":policy/userPolicy@" + TEST_TENANT_ID);
+        expectedResult.setPolicyArn("arn:aws:iam::" + TEST_TENANT_ID + ":policy/userPolicy@" + TEST_TENANT_ID);
 
         // Run the test
         final GetPolicyRequest result = ScalityModelConverter.toGetPolicyRequest(TEST_TENANT_ID);
@@ -288,7 +302,8 @@ public class ScalityModelConverterTest {
         final CreatePolicyRequest expectedResult = new CreatePolicyRequest();
         expectedResult.setPolicyName("userPolicy@" + TEST_TENANT_ID);
         expectedResult.setPolicyDocument(DEFAULT_USER_POLICY_DOCUMENT);
-        expectedResult.setDescription("This is a common user policy created by OSIS for all the users belonging to the "+ TEST_TENANT_ID +" account");
+        expectedResult.setDescription("This is a common user policy created by OSIS for all the users belonging to the "
+                + TEST_TENANT_ID + " account");
 
         // Run the test
         final CreatePolicyRequest result = ScalityModelConverter.toCreateUserPolicyRequest(TEST_TENANT_ID);
@@ -305,7 +320,8 @@ public class ScalityModelConverterTest {
         expectedResult.setPolicyArn(TEST_POLICY_ARN);
 
         // Run the test
-        final AttachUserPolicyRequest result = ScalityModelConverter.toAttachUserPolicyRequest(TEST_POLICY_ARN, TEST_USER_ID);
+        final AttachUserPolicyRequest result = ScalityModelConverter.toAttachUserPolicyRequest(TEST_POLICY_ARN,
+                TEST_USER_ID);
 
         // Verify the results
         assertEquals(expectedResult, result);
@@ -319,7 +335,8 @@ public class ScalityModelConverterTest {
         expectedResult.setPolicyArn(TEST_POLICY_ARN);
 
         // Run the test
-        final DetachUserPolicyRequest result = ScalityModelConverter.toDetachUserPolicyRequest(TEST_POLICY_ARN, TEST_USER_ID);
+        final DetachUserPolicyRequest result = ScalityModelConverter.toDetachUserPolicyRequest(TEST_POLICY_ARN,
+                TEST_USER_ID);
 
         // Verify the results
         assertEquals(expectedResult, result);
@@ -329,11 +346,12 @@ public class ScalityModelConverterTest {
     public void testToOsisUser() {
         // Setup
         final CreateUserResult createUserResult = new CreateUserResult();
-        final String path = "/"+ TEST_NAME +"/"
-                + OsisUser.RoleEnum.TENANT_USER.getValue() +"/"
-                + SAMPLE_SCALITY_USER_EMAIL  + "/"
-                + TEST_TENANT_ID  + "/";
-        createUserResult.setUser(new User(path, TEST_USER_ID, TEST_USER_ID, "arn", new GregorianCalendar(2019, Calendar.JANUARY, 1).getTime()));
+        final String path = "/" + TEST_NAME + "/"
+                + OsisUser.RoleEnum.TENANT_USER.getValue() + "/"
+                + SAMPLE_SCALITY_USER_EMAIL + "/"
+                + TEST_TENANT_ID + "/";
+        createUserResult.setUser(new User(path, TEST_USER_ID, TEST_USER_ID, "arn",
+                new GregorianCalendar(2019, Calendar.JANUARY, 1).getTime()));
 
         final OsisUser osisUser = new OsisUser();
         osisUser.setTenantId(TEST_TENANT_ID);
@@ -359,7 +377,8 @@ public class ScalityModelConverterTest {
         createAccessKeyResult.setAccessKey(new AccessKey(TEST_USER_ID, TEST_ACCESS_KEY, "status", TEST_SECRET_KEY));
 
         // Run the test
-        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, TEST_TENANT_ID, TEST_NAME, createAccessKeyResult);
+        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, TEST_TENANT_ID,
+                TEST_NAME, createAccessKeyResult);
 
         // Verify the results
         assertEquals(TEST_USER_ID, result.getCdUserId());
@@ -381,7 +400,8 @@ public class ScalityModelConverterTest {
                 .withUserName(TEST_USER_ID);
 
         // Run the test
-        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, accesskeyMetaData, TEST_SECRET_KEY);
+        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, accesskeyMetaData,
+                TEST_SECRET_KEY);
 
         // Verify the results
         assertEquals(TEST_USER_ID, result.getCdUserId());
@@ -403,7 +423,8 @@ public class ScalityModelConverterTest {
                 .withUserName(TEST_USER_ID);
 
         // Run the test
-        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, accesskeyMetaData, null);
+        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, accesskeyMetaData,
+                null);
 
         // Verify the results
         assertEquals(TEST_USER_ID, result.getCdUserId());
@@ -433,7 +454,7 @@ public class ScalityModelConverterTest {
         account.setName(SAMPLE_TENANT_NAME);
         account.setEmailAddress(SAMPLE_SCALITY_ACCOUNT_EMAIL);
         account.setId(SAMPLE_TENANT_ID);
-        account.setCustomAttributes(Collections.singletonMap(CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID , ""));
+        account.setCustomAttributes(Collections.singletonMap(CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID, ""));
         account.setCanonicalId(TEST_CANONICAL_ID);
 
         final OsisUser osisUser = new OsisUser();
@@ -460,13 +481,14 @@ public class ScalityModelConverterTest {
     @Test
     public void testToPageOfUsers() {
         // Setup
-        final String path = "/"+ TEST_NAME +"/"
-                + OsisUser.RoleEnum.TENANT_USER.getValue() +"/"
-                + SAMPLE_SCALITY_USER_EMAIL  + "/"
-                + TEST_TENANT_ID  + "/"
-                + TEST_CANONICAL_ID  + "/";
+        final String path = "/" + TEST_NAME + "/"
+                + OsisUser.RoleEnum.TENANT_USER.getValue() + "/"
+                + SAMPLE_SCALITY_USER_EMAIL + "/"
+                + TEST_TENANT_ID + "/"
+                + TEST_CANONICAL_ID + "/";
 
-        final User user = new User(path, TEST_USER_ID, TEST_USER_ID, "arn", new GregorianCalendar(2019, Calendar.JANUARY, 1).getTime());
+        final User user = new User(path, TEST_USER_ID, TEST_USER_ID, "arn",
+                new GregorianCalendar(2019, Calendar.JANUARY, 1).getTime());
 
         final ListUsersResult listUsersResult = new ListUsersResult().withUsers(Collections.singletonList(user));
         // Run the test
@@ -518,7 +540,7 @@ public class ScalityModelConverterTest {
     @Test
     public void testExtractCdTenantId() {
         // Setup
-        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID ;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID;
 
         // Run the test
         final String cdTenantId = ScalityModelConverter.extractCdTenantId(filter);
@@ -570,7 +592,7 @@ public class ScalityModelConverterTest {
                 .withStatus(StatusType.Active)
                 .withUserName(TEST_USER_ID);
         final ListAccessKeysResult listAccessKeysResult = new ListAccessKeysResult()
-                                                                .withAccessKeyMetadata(Collections.singletonList(accesskeyMetaData));
+                .withAccessKeyMetadata(Collections.singletonList(accesskeyMetaData));
 
         final Map<String, String> secretKeyMap = new HashMap<>();
         secretKeyMap.put(TEST_ACCESS_KEY, TEST_SECRET_KEY);
@@ -581,7 +603,8 @@ public class ScalityModelConverterTest {
         osisTenant.cdTenantIds(SAMPLE_CD_TENANT_IDS);
         osisTenant.active(true);
         // Run the test
-        final PageOfS3Credentials pageOfS3Credentials = ScalityModelConverter.toPageOfS3Credentials(listAccessKeysResult, 0, 1000, osisTenant, secretKeyMap);
+        final PageOfS3Credentials pageOfS3Credentials = ScalityModelConverter
+                .toPageOfS3Credentials(listAccessKeysResult, 0, 1000, osisTenant, secretKeyMap);
 
         // Verify the results
         assertTrue(pageOfS3Credentials.getItems().size() > 0);
@@ -623,7 +646,6 @@ public class ScalityModelConverterTest {
         // Secret key only for accesskeyMetaData
         secretKeyMap.put(TEST_ACCESS_KEY, TEST_SECRET_KEY);
 
-
         final OsisTenant osisTenant = new OsisTenant();
         osisTenant.tenantId(SAMPLE_TENANT_ID);
         osisTenant.name(SAMPLE_TENANT_NAME);
@@ -631,7 +653,8 @@ public class ScalityModelConverterTest {
         osisTenant.active(true);
 
         // Run the test
-        final PageOfS3Credentials pageOfS3Credentials = ScalityModelConverter.toPageOfS3Credentials(listAccessKeysResult, 0, 1000, osisTenant, secretKeyMap);
+        final PageOfS3Credentials pageOfS3Credentials = ScalityModelConverter
+                .toPageOfS3Credentials(listAccessKeysResult, 0, 1000, osisTenant, secretKeyMap);
 
         // Verify the results
         assertTrue(pageOfS3Credentials.getItems().size() > 0);
@@ -648,10 +671,11 @@ public class ScalityModelConverterTest {
         assertEquals(TEST_SECRET_KEY, resultWithSecret.getSecretKey());
 
         // Last entry should have secret key as "Not Available"
-        final OsisS3Credential resultWithNoSecret = pageOfS3Credentials.getItems().get(pageOfS3Credentials.getItems().size()-1);
+        final OsisS3Credential resultWithNoSecret = pageOfS3Credentials.getItems()
+                .get(pageOfS3Credentials.getItems().size() - 1);
 
         assertEquals(TEST_USER_ID, resultWithNoSecret.getCdUserId());
-        assertEquals(TEST_USER_ID , resultWithNoSecret.getUserId());
+        assertEquals(TEST_USER_ID, resultWithNoSecret.getUserId());
         assertEquals(SAMPLE_TENANT_ID, resultWithNoSecret.getTenantId());
         assertEquals(TEST_ACCESS_KEY_2, resultWithNoSecret.getAccessKey());
         assertEquals(NOT_AVAILABLE, resultWithNoSecret.getSecretKey());
@@ -670,7 +694,8 @@ public class ScalityModelConverterTest {
         s3Credential.secretKey(TEST_SECRET_KEY);
 
         // Run the test
-        final PageOfS3Credentials pageOfS3Credentials = ScalityModelConverter.toPageOfS3Credentials(s3Credential, SAMPLE_CD_TENANT_ID, 0, 1000);
+        final PageOfS3Credentials pageOfS3Credentials = ScalityModelConverter.toPageOfS3Credentials(s3Credential,
+                SAMPLE_CD_TENANT_ID, 0, 1000);
 
         // Verify the results
         assertEquals(1, pageOfS3Credentials.getItems().size());
@@ -689,8 +714,12 @@ public class ScalityModelConverterTest {
     @Test
     public void testMaskSecretKey() {
         // Setup
-        final String sampleLog = "{\"items\":[{\"accessKey\":\"MGUWBY4ORDS8RKUQM86P\",\"secretKey\":\"4t3peduUGjO4HYIKJZ54\\u003dGmsfgIP8HCyMS6coVfc\",\"active\":true,\"creationDate\":{\"seconds\":1623302064,\"nanos\":0},\"tenantId\":\"475396941524\",\"userId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\",\"cdUserId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\"},{\"accessKey\":\"WWA4UPWFA5EM1MKZE8ZC\",\"secretKey\":\"zjwsRPUA3SUP9aRcVc/+NUO/PPz+F77sVICwCKi\\u003d\",\"active\":true,\"creationDate\":{\"seconds\":1623301987,\"nanos\":0},\"tenantId\":\"475396941524\",\"userId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\",\"cdUserId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\"}],\"pageInfo\":{\"limit\":1000,\"offset\":0,\"total\":2}}" ;
-        final String maskedLog = "{\"items\":[{\"accessKey\":\"MGUWBY4ORDS8RKUQM86P\",\"secretKey\":\"" + MASKED_SENSITIVE_DATA_STR + "\",\"active\":true,\"creationDate\":{\"seconds\":1623302064,\"nanos\":0},\"tenantId\":\"475396941524\",\"userId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\",\"cdUserId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\"},{\"accessKey\":\"WWA4UPWFA5EM1MKZE8ZC\",\"secretKey\":\"" + MASKED_SENSITIVE_DATA_STR + "\",\"active\":true,\"creationDate\":{\"seconds\":1623301987,\"nanos\":0},\"tenantId\":\"475396941524\",\"userId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\",\"cdUserId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\"}],\"pageInfo\":{\"limit\":1000,\"offset\":0,\"total\":2}}" ;
+        final String sampleLog = "{\"items\":[{\"accessKey\":\"MGUWBY4ORDS8RKUQM86P\",\"secretKey\":\"4t3peduUGjO4HYIKJZ54\\u003dGmsfgIP8HCyMS6coVfc\",\"active\":true,\"creationDate\":{\"seconds\":1623302064,\"nanos\":0},\"tenantId\":\"475396941524\",\"userId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\",\"cdUserId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\"},{\"accessKey\":\"WWA4UPWFA5EM1MKZE8ZC\",\"secretKey\":\"zjwsRPUA3SUP9aRcVc/+NUO/PPz+F77sVICwCKi\\u003d\",\"active\":true,\"creationDate\":{\"seconds\":1623301987,\"nanos\":0},\"tenantId\":\"475396941524\",\"userId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\",\"cdUserId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\"}],\"pageInfo\":{\"limit\":1000,\"offset\":0,\"total\":2}}";
+        final String maskedLog = "{\"items\":[{\"accessKey\":\"MGUWBY4ORDS8RKUQM86P\",\"secretKey\":\""
+                + MASKED_SENSITIVE_DATA_STR
+                + "\",\"active\":true,\"creationDate\":{\"seconds\":1623302064,\"nanos\":0},\"tenantId\":\"475396941524\",\"userId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\",\"cdUserId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\"},{\"accessKey\":\"WWA4UPWFA5EM1MKZE8ZC\",\"secretKey\":\""
+                + MASKED_SENSITIVE_DATA_STR
+                + "\",\"active\":true,\"creationDate\":{\"seconds\":1623301987,\"nanos\":0},\"tenantId\":\"475396941524\",\"userId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\",\"cdUserId\":\"99da7ffe-dd82-48a2-b07b-ce200da33005\"}],\"pageInfo\":{\"limit\":1000,\"offset\":0,\"total\":2}}";
 
         // Run the test
         final String result = ScalityModelConverter.maskSecretKey(sampleLog);

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -1,7 +1,6 @@
 package com.scality.osis.utils;
 
-
-import com.vmware.osis.model.OsisTenant;
+import com.scality.osis.model.OsisTenant;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,15 +16,14 @@ public final class ScalityTestUtils {
     public static final String SAMPLE_TENANT_NAME = "tenant name";
     public static final List<String> SAMPLE_CD_TENANT_IDS = new ArrayList<>(
             Arrays.asList(
-                    "9b7e3259-aace-414c-bfd8-94daa0efefaf","7b7e3259-aace-414c-bfd8-94daa0efefaf",
-                    "5b7e3259-aace-414c-bfd8-94daa0efefaf","6b7e3259-aace-414c-bfd8-94daa0efefaf",
-                    "4b7e3259-aace-414c-bfd8-94daa0efefaf","3b7e3259-aace-414c-bfd8-94daa0efefaf")
-    );
+                    "9b7e3259-aace-414c-bfd8-94daa0efefaf", "7b7e3259-aace-414c-bfd8-94daa0efefaf",
+                    "5b7e3259-aace-414c-bfd8-94daa0efefaf", "6b7e3259-aace-414c-bfd8-94daa0efefaf",
+                    "4b7e3259-aace-414c-bfd8-94daa0efefaf", "3b7e3259-aace-414c-bfd8-94daa0efefaf"));
     public static final String TEST_ROLE_ARN = "arn:aws:iam::123123123123:role/osis";
     public static final String TEST_SESSION_NAME_PREFIX = "ROLE_SESSION_";
-    public static final String SAMPLE_ASSUME_ROLE_NAME ="osis";
+    public static final String SAMPLE_ASSUME_ROLE_NAME = "osis";
 
-    public static final Map<String, String> SAMPLE_CUSTOM_ATTRIBUTES  = new HashMap<>() ;
+    public static final Map<String, String> SAMPLE_CUSTOM_ATTRIBUTES = new HashMap<>();
     static {
         SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==9b7e3259-aace-414c-bfd8-94daa0efefaf", "");
         SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==7b7e3259-aace-414c-bfd8-94daa0efefaf", "");
@@ -35,30 +33,27 @@ public final class ScalityTestUtils {
         SAMPLE_CUSTOM_ATTRIBUTES.put("cd_tenant_id==3b7e3259-aace-414c-bfd8-94daa0efefaf", "");
     }
 
-
-
     public static final String SAMPLE_SCALITY_ACCOUNT_EMAIL = "tenant.name@osis.scality.com";
     public static final String SAMPLE_SCALITY_USER_EMAIL = "user.name@osis.scality.com";
 
-
-    public static final String TEST_TENANT_ID ="tenantId";
-    public static final String TEST_STR ="value";
-    public static final String NOT_IMPLEMENTED_EXCEPTION_ERR ="expected NotImplementedException";
-    public static final String NULL_ERR ="Expected Value. Found Null";
-    public static final String INVALID_URL_URL ="Invalid URL";
-    public static final String TEST_USER_ID ="userId";
-    public static final String TEST_CANONICAL_ID ="canonicalID";
-    public static final String TEST_NAME ="name";
-    public static final String TEST_POLICY_ARN ="policy-arn";
+    public static final String TEST_TENANT_ID = "tenantId";
+    public static final String TEST_STR = "value";
+    public static final String NOT_IMPLEMENTED_EXCEPTION_ERR = "expected NotImplementedException";
+    public static final String NULL_ERR = "Expected Value. Found Null";
+    public static final String INVALID_URL_URL = "Invalid URL";
+    public static final String TEST_USER_ID = "userId";
+    public static final String TEST_CANONICAL_ID = "canonicalID";
+    public static final String TEST_NAME = "name";
+    public static final String TEST_POLICY_ARN = "policy-arn";
     public static final String TEST_ACCESS_KEY = "access_key";
     public static final String TEST_ACCESS_KEY_2 = "access_key_2";
     public static final String TEST_SECRET_KEY = "secret_key";
     public static final String TEST_SESSION_TOKEN = "session_token";
-    public static final String TEST_CONSOLE_URL ="https://example.console.ose.scality.com";
-    public static final String TEST_S3_INTERFACE_URL ="https://localhost:8443";
-    public static final String PLATFORM_NAME ="Scality";
-    public static final String PLATFORM_VERSION ="7.10";
-    public static final String API_VERSION ="1.0.0";
+    public static final String TEST_CONSOLE_URL = "https://example.console.ose.scality.com";
+    public static final String TEST_S3_INTERFACE_URL = "https://localhost:8443";
+    public static final String PLATFORM_NAME = "Scality";
+    public static final String PLATFORM_VERSION = "7.10";
+    public static final String API_VERSION = "1.0.0";
     public static final long SAMPLE_DURATION_SECONDS = 120L;
     public static final String ACTIVE_STR = "Active";
     public static final String NA_STR = "N/A";
@@ -67,12 +62,11 @@ public final class ScalityTestUtils {
     public static final String TEST_INVALID_CIPHER_SECRET_KEY = "dGhpc2lzYXJlYWxseWxvbmdhbmRzZXk=hgJfad==";
     public static final String TEST_CIPHER_ID = "1";
 
-
-    private ScalityTestUtils(){
+    private ScalityTestUtils() {
 
     }
 
-    public static OsisTenant createSampleOsisTenantObj(){
+    public static OsisTenant createSampleOsisTenantObj() {
         final OsisTenant osisTenantReq = new OsisTenant();
         osisTenantReq.tenantId(SAMPLE_ID);
         osisTenantReq.name(SAMPLE_TENANT_NAME);


### PR DESCRIPTION
Currently, its very difficult in adding new platform level APIs. We have duplicate and unused VMware Beans which conflicts with Scality package beans.

This PR will remove all references of VMware stub code and migrate needed code to Scality package.
Optimizing this code base is out of scope of this PR, as we are very close to a release and delivery of commitment.

We will work on refactoring the code base more in RING-39613 and OSIS-52