### PR TITLE
bugfix: OSIS-54-CVE-2022-21724

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ configure(allprojects) {
         compile 'org.openapitools:jackson-databind-nullable:0.1.0'
         compile 'javax.validation:validation-api:2.0.1.Final'
         compile 'org.hsqldb:hsqldb:2.3.2'
-        compile 'org.postgresql:postgresql:42.2.13'
+        compile 'org.postgresql:postgresql:42.2.25'
         compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.11.0'
         compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.11.0'
         compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'


### PR DESCRIPTION
- Update to next minor version (v42.2.13 -> v42.2.25) for package org.postgresql:postgresql
- change log: https://jdbc.postgresql.org/documentation/changelog.html#version_42.2.25

After change:
```
❯ trivy image registry.scality.com/osis-dev/osis:b22d2fc2e3 | grep 21724
2022-07-04T14:35:26.458+0200	INFO	Vulnerability scanning is enabled
2022-07-04T14:35:26.458+0200	INFO	Secret scanning is enabled
2022-07-04T14:35:26.458+0200	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-07-04T14:35:26.458+0200	INFO	Please see also https://aquasecurity.github.io/trivy/v0.29.1/docs/secret/scanning/#recommendation for faster secret detection
2022-07-04T14:35:48.616+0200	INFO	Detected OS: alpine
2022-07-04T14:35:48.616+0200	INFO	Detecting Alpine vulnerabilities...
2022-07-04T14:35:48.622+0200	INFO	Number of language-specific files: 1
2022-07-04T14:35:48.622+0200	INFO	Detecting jar vulnerabilities...
2022-07-04T14:35:48.664+0200	INFO	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.
```

Before change:
```
❯ trivy image registry.scality.com/playground/amittal/osis:0.4.22 | grep 21724
2022-07-04T14:36:09.541+0200	INFO	Vulnerability scanning is enabled
2022-07-04T14:36:09.541+0200	INFO	Secret scanning is enabled
2022-07-04T14:36:09.541+0200	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-07-04T14:36:09.541+0200	INFO	Please see also https://aquasecurity.github.io/trivy/v0.29.1/docs/secret/scanning/#recommendation for faster secret detection
2022-07-04T14:36:09.555+0200	INFO	Detected OS: alpine
2022-07-04T14:36:09.555+0200	INFO	Detecting Alpine vulnerabilities...
2022-07-04T14:36:09.556+0200	INFO	Number of language-specific files: 1
2022-07-04T14:36:09.556+0200	INFO	Detecting jar vulnerabilities...
2022-07-04T14:36:09.563+0200	INFO	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.
│ org.postgresql:postgresql (app.jar)                         │ CVE-2022-21724      │ CRITICAL │ 42.2.13           │ 42.2.25, 42.3.2                                 │ jdbc-postgresql: Unchecked Class Instantiation when          │
│                                                             │                     │          │                   │                                                 │ https://avd.aquasec.com/nvd/cve-2022-21724                   │
```