### PR TITLE
Feature/osis 66 implement get bucket list

### DIFF
--- a/osis-app/src/main/java/com/scality/osis/healthcheck/S3HealthIndicator.java
+++ b/osis-app/src/main/java/com/scality/osis/healthcheck/S3HealthIndicator.java
@@ -1,0 +1,52 @@
+/**
+ *Copyright 2021 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.healthcheck;
+
+import com.scality.osis.ScalityAppEnv;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+
+@Component("s3")
+public class S3HealthIndicator implements HealthIndicator {
+    private static final Logger logger = LoggerFactory.getLogger(S3HealthIndicator.class);
+
+    @Autowired
+    private ScalityAppEnv appEnv;
+
+    @Override
+    public Health health() {
+        HttpURLConnection connection = null;
+        try {
+            // check if S3 Endpoint is reachable
+            connection = (HttpURLConnection) new java.net.URL(appEnv.getS3Endpoint()).openConnection();
+            connection.setConnectTimeout(appEnv.getS3HealthCheckTimeout());
+            connection.connect();
+        } catch (SocketTimeoutException e) {
+            logger.warn("Failed to connect to S3 endpoint {} in timeout {}",appEnv.getS3Endpoint(), appEnv.getS3HealthCheckTimeout());
+            return Health.down()
+                    .withDetail("error", e.getMessage())
+                    .build();
+        } catch (IOException e) {
+            logger.warn("an I/O error occurs while trying to connect {}.",appEnv.getS3Endpoint());
+            return Health.down()
+                    .withDetail("error", e.getMessage())
+                    .build();
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        return Health.up().build();
+    }
+}

--- a/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
+++ b/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
@@ -217,11 +217,10 @@ public class ScalityOsisController {
     }, tags = { "bucketlist", "optional", })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "The bucket list of the platform tenant is returned", response = OsisBucketMeta.class, responseContainer = "List"),
-            @ApiResponse(code = 501, message = "The optional API is not implemented") })
+    })
     @ApiImplicitParams({
     })
     @GetMapping(value = "/api/v1/bucket-list", produces = "application/json")
-    @NotImplement(name = ScalityOsisConstants.GET_BUCKET_LIST_API_CODE)
     public PageOfOsisBucketMeta getBucketList(
             @NotNull @ApiParam(value = "The ID of the tenant to get its bueckt list", required = true) @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
             @ApiParam(value = "The start index of buckets to return") @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") long offset,

--- a/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
+++ b/osis-core/src/main/java/com/scality/osis/ScalityAppEnv.java
@@ -18,12 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.scality.osis.utils.ScalityConstants.DEFAULT_ACCOUNT_AK_DURATION_SECONDS;
-import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_CORE_POOL_SIZE;
-import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_MAX_POOL_SIZE;
-import static com.scality.osis.utils.ScalityConstants.DEFAULT_ASYNC_EXECUTOR_QUEUE_CAPACITY;
-import static com.scality.osis.utils.ScalityConstants.DEFAULT_SPRING_CACHE_TYPE;
-import static com.scality.osis.utils.ScalityConstants.DEFAULT_VAULT_HEALTHCHECK_TIMEOUT;
+import static com.scality.osis.utils.ScalityConstants.*;
 
 @Component
 @Primary
@@ -185,6 +180,14 @@ public class ScalityAppEnv {
 
     // function migrated from VMware Ceph implementation AppEnv
     public String getS3Endpoint() {
-        return env.getProperty("osis.scality.vaultS3Interface.endpoint");
+        return env.getProperty("osis.scality.s3.endpoint");
+    }
+
+    public int getS3HealthCheckTimeout() {
+        String s3HealthCheckTimeout =  env.getProperty("osis.scality.s3.healthcheck.timeout");
+        if(StringUtils.isBlank(s3HealthCheckTimeout)) {
+            s3HealthCheckTimeout = DEFAULT_S3_HEALTHCHECK_TIMEOUT;
+        }
+        return Integer.parseInt(s3HealthCheckTimeout);
     }
 }

--- a/osis-core/src/main/java/com/scality/osis/model/PageInfo.java
+++ b/osis-core/src/main/java/com/scality/osis/model/PageInfo.java
@@ -20,6 +20,20 @@ public class PageInfo {
   @NotNull
   private Long total;
 
+  public PageInfo() {}
+
+  public PageInfo(Long limit, Long offset) {
+    this.limit = limit;
+    this.offset = offset;
+    this.total = 0L;
+  }
+
+  public PageInfo(Long limit, Long offset, Long total) {
+    this.limit = limit;
+    this.offset = offset;
+    this.total = total;
+  }
+
   public PageInfo limit(Long limit) {
     this.limit = limit;
     return this;

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -83,7 +83,8 @@ public final class ScalityConstants {
             "      {\n" +
             "         \"Effect\":\"Allow\",\n" +
             "         \"Action\":[\n" +
-            "            \"iam:*\"\n" +
+            "            \"iam:*\",\n" +
+            "            \"s3:*\"\n" +
             "         ],\n" +
             "         \"Resource\":\"*\"\n" +
             "      }\n" +
@@ -101,6 +102,7 @@ public final class ScalityConstants {
     public static final String DEFAULT_ASYNC_EXECUTOR_QUEUE_CAPACITY = "500";
 
     public static final String DEFAULT_VAULT_HEALTHCHECK_TIMEOUT = "3000";
+    public static final String DEFAULT_S3_HEALTHCHECK_TIMEOUT = "3000";
     public static final String HEALTH_CHECK_ENDPOINT = "/_/healthcheck";
 
     public static final String USER_POLICY_ARN_REGEX = "arn:aws:iam::$ACCOUNTID:policy/userPolicy@$ACCOUNTID";

--- a/osis-core/src/test/java/com/scality/osis/ScalityAppEnvTest.java
+++ b/osis-core/src/test/java/com/scality/osis/ScalityAppEnvTest.java
@@ -488,4 +488,40 @@ public class ScalityAppEnvTest {
         // Verify the results
         assertThat(result).isEqualTo(500);
     }
+
+    @Test
+    public void testGetS3Endpoint() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.s3.endpoint")).thenReturn(TEST_RESULT);
+
+        // Run the test
+        final String result = appEnvUnderTest.getS3Endpoint();
+
+        // Verify the results
+        assertEquals(result, TEST_RESULT, "testGetS3Endpoint failed");
+    }
+
+    @Test
+    public void testGetS3EndpointEnvironmentReturnsNull() {
+        // Setup
+        when(mockEnv.getProperty("osis.scality.s3.endpoint")).thenReturn(null);
+
+        // Run the test
+        final String result = appEnvUnderTest.getS3Endpoint();
+
+        // Verify the results
+        assertNull(result, TEST_RESULT_NULL_ERR);
+    }
+
+    @Test
+    public void testGetS3HealthCheckTimeout() {
+        //Setup
+        when(mockEnv.getProperty("osis.scality.s3.healthcheck.timeout")).thenReturn("3000");
+
+        // Run the test
+        final Integer result = appEnvUnderTest.getS3HealthCheckTimeout();
+
+        // Verify the results
+        assertEquals(result, 3000, "testGetS3HealthCheckTimeout failed");
+    }
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
@@ -321,6 +321,47 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest {
     }
 
     @Test
+    public void testQueryUsersWithCdTenantIdEqualsToTenantIdAndDisplayNameEqualsToUserId() {
+        // Setup
+        final long offset = 0L;
+        final long limit = 1000L;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX
+                + SAMPLE_ID;
+        // cd_tenant_id==971317116260;display_name==f3bbe501-29b0-4891-8602-a4e2f95101f8
+
+        // Run the test
+        final PageOfUsers response = scalityOsisServiceUnderTest.queryUsers(offset, limit, filter);
+
+        // Verify the results
+        assertEquals(1, response.getPageInfo().getTotal());
+        assertEquals(offset, response.getPageInfo().getOffset());
+        assertEquals(limit, response.getPageInfo().getLimit());
+        assertEquals(1, response.getItems().size());
+        assertEquals(SAMPLE_ID, response.getItems().get(0).getUserId());
+        assertTrue(response.getItems().get(0).getTenantId().contains(SAMPLE_TENANT_ID));
+    }
+
+    @Test
+    public void testQueryUsersWithCdTenantIdEqualsToTenantIdAndDisplayNameEqualsToTenantName() {
+        // Setup
+        final long offset = 0L;
+        final long limit = 1000L;
+        final String filter = CD_TENANT_ID_PREFIX + SAMPLE_TENANT_ID + FILTER_SEPARATOR + DISPLAY_NAME_PREFIX
+                + SAMPLE_TENANT_NAME;
+        // cd_tenant_id==971317116260;display_name==tenant_name
+
+        // Run the test
+        final PageOfUsers response = scalityOsisServiceUnderTest.queryUsers(offset, limit, filter);
+
+        // Verify the results
+        assertEquals(limit, response.getPageInfo().getTotal());
+        assertEquals(offset, response.getPageInfo().getOffset());
+        assertEquals(limit, response.getPageInfo().getLimit());
+        assertEquals(limit, response.getItems().size());
+        assertTrue(response.getItems().get(0).getTenantId().contains(SAMPLE_TENANT_ID));
+    }
+
+    @Test
     public void testDeleteUser() {
         // Setup
 

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public final class ScalityTestUtils {
 
     public static final String SAMPLE_TENANT_ID = "123123123123";
-    public static final String SAMPLE_ID = "bfc0d4a51e06481cbc917e9d96e52d81";
+    public static final String SAMPLE_ID = "f3bbe501-29b0-4891-8602-a4e2f95101f8";
     public static final String SAMPLE_CD_TENANT_ID = "5db7b952-66b9-4164-bfe2-7bab25ac9011";
     public static final String SAMPLE_TENANT_NAME = "tenant name";
     public static final List<String> SAMPLE_CD_TENANT_IDS = new ArrayList<>(
@@ -45,6 +45,7 @@ public final class ScalityTestUtils {
     public static final String TEST_USER_ID = "userId";
     public static final String TEST_CANONICAL_ID = "canonicalID";
     public static final String TEST_NAME = "name";
+    public static final String TEST_BUCKET_NAME = "bucket_name";
     public static final String TEST_POLICY_ARN = "policy-arn";
     public static final String TEST_ACCESS_KEY = "access_key";
     public static final String TEST_ACCESS_KEY_2 = "access_key_2";
@@ -53,6 +54,7 @@ public final class ScalityTestUtils {
     public static final String TEST_CONSOLE_URL = "https://example.console.ose.scality.com";
     public static final String TEST_S3_INTERFACE_URL = "https://localhost:8443";
     public static final String TEST_S3_CAPABILITIES_FILE_PATH = "s3capabilities.json";
+    public static final String TEST_S3_URL = "http://localhost:8000";
     public static final String PLATFORM_NAME = "Scality";
     public static final String PLATFORM_VERSION = "7.10";
     public static final String API_VERSION = "1.3.0-SNAPSHOT";
@@ -63,6 +65,8 @@ public final class ScalityTestUtils {
     public static final String TEST_CIPHER_SECRET_KEY = "dGhpc2lzYXJlYWxseWxvbmdhbmRzZXk=";
     public static final String TEST_INVALID_CIPHER_SECRET_KEY = "dGhpc2lzYXJlYWxseWxvbmdhbmRzZXk=hgJfad==";
     public static final String TEST_CIPHER_ID = "1";
+
+    public static final long TEST_BUCKET_TOTAL_NUMBER = 10000L;
 
     private ScalityTestUtils() {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,10 @@ osis.scality.vault.cache.accountID.ttlInMS=360000
 # Vault S3 interface configuration
 osis.scality.vaultS3Interface.endpoint=http://localhost:8500
 
+# S3 Config
+osis.scality.s3.endpoint=http://localhost:8000
+osis.scality.s3.healthcheck.timeout=3000
+
 # Provider Console Endpoint
 osis.scality.console.endpoint=https://dashboard.scality.osis.ose.vmware.com:30610
 

--- a/storage-platform-clients/src/main/java/com/scality/osis/s3/S3.java
+++ b/storage-platform-clients/src/main/java/com/scality/osis/s3/S3.java
@@ -1,0 +1,8 @@
+package com.scality.osis.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.securitytoken.model.Credentials;
+
+public interface S3 {
+    AmazonS3 getS3Client(Credentials credentials, String region);
+}

--- a/storage-platform-clients/src/main/java/com/scality/osis/s3/impl/S3Impl.java
+++ b/storage-platform-clients/src/main/java/com/scality/osis/s3/impl/S3Impl.java
@@ -1,0 +1,72 @@
+package com.scality.osis.s3.impl;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import com.amazonaws.util.StringUtils;
+import com.scality.osis.s3.S3;
+import okhttp3.HttpUrl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class S3Impl implements S3 {
+
+    private final String s3Endpoint;
+
+    /**
+     * Create a s3 client implementation
+     *
+     * @param s3Endpoint s3 API endpoint
+     */
+    @Autowired
+    public S3Impl(@Value("${osis.scality.s3.endpoint}") String s3Endpoint) {
+        validEndpoint(s3Endpoint);
+        this.s3Endpoint = s3Endpoint;
+    }
+
+    /**
+     * Validate endpoint. If error throw exception
+     *
+     * @param endpoint s3 API endpoint
+     */
+    private static void validEndpoint(String endpoint) {
+        if (HttpUrl.parse(endpoint) == null) {
+            throw new IllegalArgumentException("endpoint is invalid");
+        }
+    }
+
+    @Override
+    public AmazonS3 getS3Client(Credentials credentials, String region) {
+        if (StringUtils.isNullOrEmpty(credentials.getSessionToken())) {
+            return AmazonS3ClientBuilder
+                    .standard()
+                    .withCredentials(
+                            new AWSStaticCredentialsProvider(
+                                    new BasicAWSCredentials(
+                                            credentials.getAccessKeyId(),
+                                            credentials.getSecretAccessKey())))
+                    .withEndpointConfiguration(
+                            new AwsClientBuilder.EndpointConfiguration(s3Endpoint, region))
+                    .build();
+        } else {
+            return AmazonS3ClientBuilder
+                    .standard()
+                    .withCredentials(
+                            new AWSStaticCredentialsProvider(
+                                    new BasicSessionCredentials(
+                                            credentials.getAccessKeyId(),
+                                            credentials.getSecretAccessKey(),
+                                            credentials.getSessionToken())))
+                    .withEndpointConfiguration(
+                            new AwsClientBuilder.EndpointConfiguration(s3Endpoint, region))
+                    .build();
+        }
+    }
+}

--- a/storage-platform-clients/src/main/java/com/scality/osis/s3/impl/S3ServiceException.java
+++ b/storage-platform-clients/src/main/java/com/scality/osis/s3/impl/S3ServiceException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2021 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.s3.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Represents S3 errors
+ *
+ */
+@SuppressWarnings("SameParameterValue")
+public class S3ServiceException extends ResponseStatusException {
+
+  private static final long serialVersionUID = 8292089200348420677L;
+
+  private String errorCode = "";
+
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+  public S3ServiceException(HttpStatus status, String message) {
+    super(status, message);
+  }
+
+  public S3ServiceException(HttpStatus status, String errorCode, String message) {
+    super(status, message);
+    this.errorCode = errorCode;
+  }
+
+  public S3ServiceException(HttpStatus status, String messageCode, Throwable cause) {
+    super(status, messageCode, cause);
+  }
+}

--- a/storage-platform-clients/src/test/java/com/scality/osis/s3/impl/S3ImplTest.java
+++ b/storage-platform-clients/src/test/java/com/scality/osis/s3/impl/S3ImplTest.java
@@ -1,0 +1,65 @@
+package com.scality.osis.s3.impl;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.securitytoken.model.Credentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class S3ImplTest {
+
+    public S3Impl s3Impl;
+    public String s3Endpoint;
+
+    public static final String TEST_ACCESS_KEY = "access_key";
+    public static final String TEST_SECRET_KEY = "secret_key";
+    public static final String TEST_SESSION_TOKEN = "session_token";
+    public static final String TEST_REGION = "us-east-1";
+
+    @BeforeEach
+    public void init() throws IOException {
+        String env = System.getProperty("env", "");
+        if (!StringUtils.isBlank(env)) {
+            env = "." + env;
+        }
+        final Properties properties = new Properties();
+        properties.load(S3ImplTest.class.getResourceAsStream("/storage-platform-clients.properties" + env));
+
+        s3Endpoint = properties.getProperty("s3.endpoint");
+        s3Impl = new S3Impl(s3Endpoint);
+    }
+
+    @Test
+    public void testS3ImplInvalidEndpoint() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new S3Impl("invalid_s3_endpoint"),
+                "S3Impl constructor should throw IllegalArgumentException for null endpoint");
+    }
+
+    @Test
+    public void testGetS3Client() {
+        final Credentials credentials = new Credentials();
+        credentials.setAccessKeyId(TEST_ACCESS_KEY);
+        credentials.setSecretAccessKey(TEST_SECRET_KEY);
+
+        final AmazonS3 s3Client = s3Impl.getS3Client(credentials, TEST_REGION);
+        assertNotNull(s3Client);
+    }
+
+    @Test
+    public void testGetS3ClientWithSession() {
+        final Credentials credentials = new Credentials();
+        credentials.setAccessKeyId(TEST_ACCESS_KEY);
+        credentials.setSecretAccessKey(TEST_SECRET_KEY);
+        credentials.setSessionToken(TEST_SESSION_TOKEN);
+
+        final AmazonS3 s3Client = s3Impl.getS3Client(credentials, TEST_REGION);
+        assertNotNull(s3Client);
+    }
+}

--- a/storage-platform-clients/src/test/java/com/scality/osis/vaultadmin/impl/BaseTest.java
+++ b/storage-platform-clients/src/test/java/com/scality/osis/vaultadmin/impl/BaseTest.java
@@ -293,7 +293,7 @@ public class BaseTest {
       env = "." + env;
     }
     final Properties properties = new Properties();
-    properties.load(VaultAdminImplTest.class.getResourceAsStream("/vaultadmin.properties" + env));
+    properties.load(VaultAdminImplTest.class.getResourceAsStream("/storage-platform-clients.properties" + env));
 
     adminUserId = properties.getProperty("vault.adminId");
     adminAccessKey = properties.getProperty("vault.adminAccessKey");

--- a/storage-platform-clients/src/test/resources/storage-platform-clients.properties
+++ b/storage-platform-clients/src/test/resources/storage-platform-clients.properties
@@ -5,4 +5,4 @@ vault.adminEndpoint=http://localhost:8600
 vault.adminAccessKey=TESTACCESSKEY
 vault.adminSecretKey=TESTSECRETKEY
 vault.adminId=qqq
-
+s3.endpoint=http://127.0.0.1:8000


### PR DESCRIPTION
commit1: add s3 client implementation and tests (call aws SDK getS3Client)
commit2: implement getBucketList API and add several scality model converters to be able to be compatible with cloudserver listBucket call.
commit3: add getBucketList tests
commit4: add s3 endpoint health check
commit5: update getInfo API with real s3 endpoint( before was using vault s3 interface 8500 )
commit6: remove notImplemented annotation, enable getBucketList
commit7: setup SetupAssumeRolePolicy flow for getBucketList (common workflow of osis APIs, if you are interested, please have a look at the[ design doc](https://github.com/scality/osis/blob/development/1.1/Design.md))
commit8: add more test