### PR TITLE
feature: OSIS-70-list-all-accounts-without-filter

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -76,7 +76,6 @@ This API will list tenants on Vault.
 * Vault `list-accounts` api will be called using vaultclient with parameters
    1. `marker` (if exists from `markerCache`)
    1. `max-limit`
-   1.  `filterKeyStartsWith=cd_tenant_id` (Only return the accounts with at least one `cd_tenant_id`)
 
 * <u>`markerCache`</u>
     * Every time `List Accounts` API is called by the OSIS, if `isTruncated` is `true` in the response, then `marker` value will be stored in the `markerCache` with the key as `(max-limit +1)`

--- a/docs/api-compatibility-matrix.md
+++ b/docs/api-compatibility-matrix.md
@@ -19,37 +19,37 @@ Legend
 * `o` - implemented with default stub
 * `*` - Mandatory APIs to integrate with OSE for essential functions, like basic S3 bucket/object CRUD operations
 
-| API  | Milestone 1 | Milestone 2 | Milestone 3 | Milestone 4 |
-|:-----|:------------|:------------|-------------|-------------|
-| headTenant * | . | . | . | x |
-| getTenant | . | . | . | . |
-| updateTenant * | . | . | . | x |
-| deleteTenant | . | . | . | . |
-| listTenants * | x | x | x | x |
-| createTenant * | x | x | x | x |
-| queryTenants * | x | x | x | x |
-| queryUsers * | . | x | x | x |
-| createUser * | . | x | x | x |
-| listUsers * | . | x | x | x |
-| getUserWithId * | . | x | x | x |
-| headUser | . | . | . | . |
-| updateUserStatus * | . | . | . | . |
-| deleteUser * | . | . | . | x |
-| getUserWithCanonicalID * | . | . | x | x |
-| queryCredentials * | . | . | x | x |
-| listCredentials * | . | x | x | x |
-| createCredential * | . | x | x | x |
-| getCredential * | . | . | x | x |
-| updateCredentialStatus | . | . | . | . |
-| deleteCredential | . | . | . | x |
-| getUsage | o | o | o | o |
-| getBucketList | . | . | . | . |
-| getBucketLoggingId | . | . | . | . |
-| getAnonymousUser | . | . | . | . |
-| getConsole | o | o | o | o |
-| getS3Capabilities * | o | x | x | x |
-| getInfo * | o | o | o | x |
-| refreshToken *  | o | o | o | o |
+| API                      | Milestone 1 | Milestone 2 | Milestone 3 | Milestone 4 | Milestone 5 |
+|:-------------------------|:------------|:------------|-------------|-------------|-------------|
+| headTenant *             | .           | .           | .           | x           | x           |
+| getTenant                | .           | .           | .           | .           | .           |
+| updateTenant *           | .           | .           | .           | x           | x           |
+| deleteTenant             | .           | .           | .           | .           | .           |
+| listTenants *            | x           | x           | x           | x           | x           |
+| createTenant *           | x           | x           | x           | x           | x           |
+| queryTenants *           | x           | x           | x           | x           | x           |
+| queryUsers *             | .           | x           | x           | x           | x           |
+| createUser *             | .           | x           | x           | x           | x           |
+| listUsers *              | .           | x           | x           | x           | x           |
+| getUserWithId *          | .           | x           | x           | x           | x           |
+| headUser                 | .           | .           | .           | .           | x           |
+| updateUserStatus *       | .           | .           | .           | .           | .           |
+| deleteUser *             | .           | .           | .           | x           | x           |
+| getUserWithCanonicalID * | .           | .           | x           | x           | x           |
+| queryCredentials *       | .           | .           | x           | x           | x           |
+| listCredentials *        | .           | x           | x           | x           | x           |
+| createCredential *       | .           | x           | x           | x           | x           |
+| getCredential *          | .           | .           | x           | x           | x           |
+| updateCredentialStatus   | .           | .           | .           | .           | .           |
+| deleteCredential         | .           | .           | .           | x           | x           |
+| getUsage                 | o           | o           | o           | o           | .           |
+| getBucketList            | .           | .           | .           | .           | .           |
+| getBucketLoggingId       | .           | .           | .           | .           | .           |
+| getAnonymousUser         | .           | .           | .           | .           | .           |
+| getConsole               | o           | o           | o           | o           | .           |
+| getS3Capabilities *      | o           | x           | x           | x           | x           |
+| getInfo *                | o           | o           | o           | x           | x           |
+| refreshToken *           | o           | o           | o           | x           | x           |
 
 ### Required APIs
 

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -107,7 +107,6 @@ public final class ScalityModelConverter {
     public static ListAccountsRequestDTO toScalityListAccountsRequest(long limit) {
         return ListAccountsRequestDTO.builder()
                 .maxItems((int) limit)
-                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
     }
 

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -34,6 +34,15 @@ public class ScalityModelConverterTest {
     }
 
     @Test
+    public void testToScalityListAccountsRequest() {
+        final ListAccountsRequestDTO listAccountsRequest = ScalityModelConverter
+                .toScalityListAccountsRequest(100);
+
+        assertEquals(100, listAccountsRequest.getMaxItems());
+        assertEquals(null, listAccountsRequest.getFilterKeyStartsWith());
+    }
+
+    @Test
     public void testToOsisCDTenantIdsTest() {
         final List<String> result = ScalityModelConverter.toOsisCDTenantIds(SAMPLE_CUSTOM_ATTRIBUTES);
         assertTrue(SAMPLE_CD_TENANT_IDS.size() == result.size() &&

--- a/storage-platform-clients/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
+++ b/storage-platform-clients/src/test/java/com/scality/osis/vaultadmin/impl/VaultAdminImplTest.java
@@ -135,16 +135,11 @@ public class VaultAdminImplTest extends BaseTest {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
                 .maxItems(5)
-                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         final ListAccountsResponseDTO response = vaultAdminImpl.listAccounts(listAccountsRequestDTO);
         assertNotEquals(0, response.getAccounts().size());
-        assertFalse(response.getAccounts().get(0).getCustomAttributes().isEmpty());
-        assertTrue(response.getAccounts().get(0)
-                .getCustomAttributes().keySet()
-                .stream().findFirst().get()
-                .startsWith(CD_TENANT_ID_PREFIX));
+        assertEquals(response.getAccounts().get(0).getCustomAttributes(), null);
     }
 
     @Test
@@ -152,7 +147,6 @@ public class VaultAdminImplTest extends BaseTest {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
                 .maxItems(5)
-                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         when(accountServicesClient.listAccounts(any(ListAccountsRequestDTO.class)))
@@ -178,7 +172,6 @@ public class VaultAdminImplTest extends BaseTest {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
                 .maxItems(5)
-                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         when(accountServicesClient.listAccounts(any(ListAccountsRequestDTO.class)))
@@ -282,16 +275,11 @@ public class VaultAdminImplTest extends BaseTest {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
                 .maxItems(1000)
-                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         final ListAccountsResponseDTO response = vaultAdminImpl.listAccounts(3000, listAccountsRequestDTO);
         assertEquals(1000, response.getAccounts().size());
-        assertFalse(response.getAccounts().get(0).getCustomAttributes().isEmpty());
-        assertTrue(response.getAccounts().get(0)
-                .getCustomAttributes().keySet()
-                .stream().findFirst().get()
-                .startsWith(CD_TENANT_ID_PREFIX));
+        assertEquals(response.getAccounts().get(0).getCustomAttributes(), null);
     }
 
     @Test
@@ -308,17 +296,12 @@ public class VaultAdminImplTest extends BaseTest {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
                 .maxItems(1000)
-                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         final ListAccountsResponseDTO response = vaultAdminImpl.listAccounts(1000, listAccountsRequestDTO);
         assertEquals(1000, response.getAccounts().size());
         assertEquals("M2000", response.getMarker());
-        assertFalse(response.getAccounts().get(0).getCustomAttributes().isEmpty());
-        assertTrue(response.getAccounts().get(0)
-                .getCustomAttributes().keySet()
-                .stream().findFirst().get()
-                .startsWith(CD_TENANT_ID_PREFIX));
+        assertEquals(response.getAccounts().get(0).getCustomAttributes(), null);
     }
 
     @Test
@@ -335,17 +318,12 @@ public class VaultAdminImplTest extends BaseTest {
 
         final ListAccountsRequestDTO   listAccountsRequestDTO = ListAccountsRequestDTO.builder()
                 .maxItems(1000)
-                .filterKeyStartsWith(CD_TENANT_ID_PREFIX)
                 .build();
 
         final ListAccountsResponseDTO response = vaultAdminImpl.listAccounts(3000, listAccountsRequestDTO);
         assertEquals(1000, response.getAccounts().size());
         assertEquals("M4000", response.getMarker());
-        assertFalse(response.getAccounts().get(0).getCustomAttributes().isEmpty());
-        assertTrue(response.getAccounts().get(0)
-                .getCustomAttributes().keySet()
-                .stream().findFirst().get()
-                .startsWith(CD_TENANT_ID_PREFIX));
+        assertEquals(response.getAccounts().get(0).getCustomAttributes(), null);
     }
 
     @Test


### PR DESCRIPTION
We originally wanted OSIS to only list accounts created via VCD
But as we also want accounts created before VCD to be linked to VCD tenants, we now call list accounts without filterKeyStartsWith.