### PR TITLE
Feature/osis 73 update s3credential status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ configure(allprojects) {
         compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
         compile 'io.jsonwebtoken:jjwt:0.9.1'
         implementation 'org.springframework.plugin:spring-plugin-core:1.2.0.RELEASE'
-        implementation 'com.scality:vaultclient:0.4.0-SNAPSHOT'
+        implementation 'com.scality:vaultclient:0.5.0'
         implementation 'com.amazonaws:aws-java-sdk-s3:1.11.914'
         implementation 'com.amazonaws:aws-java-sdk-sts:1.11.914'
         implementation 'com.amazonaws:aws-java-sdk-iam:1.11.914'

--- a/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
+++ b/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
@@ -589,18 +589,16 @@ public class ScalityOsisController {
     }, tags = { "s3credential", "optional", })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "The status of the S3 credential is updated", response = OsisS3Credential.class),
-            @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
-            @ApiResponse(code = 501, message = "The optional API is not implemented") })
+            @ApiResponse(code = 400, message = "Bad Request", response = Error.class)})
     @ApiImplicitParams({
     })
     @PatchMapping(value = "/api/v1/s3credentials/{accessKey}", produces = "application/json", consumes = "application/json")
-    @NotImplement(name = ScalityOsisConstants.UPDATE_CREDENTIAL_STATUS_API_CODE)
     public OsisS3Credential updateCredentialStatus(
-            @NotNull @ApiParam(value = "The ID of the tenant which the user belongs to", required = true) @Valid @RequestParam(value = "tenant_id", required = true) String tenantId,
-            @NotNull @ApiParam(value = "The ID of the user which the status updated S3 credential belongs to", required = true) @Valid @RequestParam(value = "user_id", required = true) String userId,
-            @ApiParam(value = "The access key of the S3 credential to update status", required = true) @PathVariable("accessKey") String accessKey,
-            @ApiParam(value = "The S3 credential containing the status to update. Only property 'active' takes effect", required = true) @Valid @RequestBody OsisS3Credential osisS3Credential) {
-        throw new NotImplementedException();
+            @ApiParam(value = "The ID of the tenant which the user belongs to") @RequestParam(value = "tenant_id", required = false) String tenantId,
+            @ApiParam(value = "The ID of the user which the status updated S3 credential belongs to") @RequestParam(value = "user_id", required = false) String userId,
+            @NotNull @ApiParam(value = "The access key of the S3 credential to update status", required = true) @PathVariable("accessKey") String accessKey,
+            @ApiParam(value = "The S3 credential containing the status to update. Only property 'active' takes effect", required = true) @RequestBody OsisS3Credential osisS3Credential) {
+        return osisService.updateCredentialStatus(tenantId, userId, accessKey, osisS3Credential);
     }
 
     /**

--- a/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
@@ -56,6 +56,8 @@ public interface ScalityOsisService {
 
     PageOfS3Credentials listS3Credentials(String tenantId, String userId, Long offset, Long limit);
 
+    OsisS3Credential updateCredentialStatus(String tenantId, String userId, String accessKey, OsisS3Credential osisS3Credential);
+
     String getProviderConsoleUrl();
 
     String getTenantConsoleUrl(String tenantId);

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -9,6 +9,14 @@ import com.amazonaws.services.identitymanagement.model.User;
 import com.amazonaws.services.identitymanagement.model.*;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
+import com.scality.vaultclient.dto.*;
+import com.scality.osis.model.OsisS3Credential;
+import com.scality.osis.model.OsisTenant;
+import com.scality.osis.model.OsisUser;
+import com.scality.osis.model.PageInfo;
+import com.scality.osis.model.PageOfS3Credentials;
+import com.scality.osis.model.PageOfTenants;
+import com.scality.osis.model.PageOfUsers;
 import com.scality.osis.model.*;
 import com.scality.osis.model.exception.BadRequestException;
 import com.scality.vaultclient.dto.*;
@@ -95,6 +103,19 @@ public final class ScalityModelConverter {
     }
 
     /**
+     * Converts accessKey to Vault Get User by AccessKey request
+     *
+     * @param accessKey the accessKey
+     *
+     * @return the Get User by AccessKey request dto
+     */
+    public static GetUserByAccessKeyRequestDTO toScalityGetUserByAccessKeyRequest(String accessKey) {
+        return GetUserByAccessKeyRequestDTO.builder()
+                .accessKey(accessKey)
+                .build();
+    }
+
+    /**
      * Creates Vault List Users request for List users
      *
      * @param limit  the max number of items
@@ -126,8 +147,9 @@ public final class ScalityModelConverter {
      * Creates Vault Update Access Key request
      *
      * @param username the IAM User's username
-     * @param limit    the max number of the access keys in the response
-     * @return the IAM list Access Keys request dto
+     * @param accessKey access key
+     * @param isActive true/false
+     * @return the IAM update Access Keys request dto
      */
     public static UpdateAccessKeyRequest toIAMUpdateAccessKeyRequest(String username, String accessKey,
             Boolean isActive) {

--- a/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
@@ -2,6 +2,7 @@ package com.scality.osis.service.impl;
 
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.model.*;
+import com.amazonaws.services.identitymanagement.model.User;
 import com.amazonaws.services.securitytoken.model.*;
 import com.scality.osis.ScalityAppEnv;
 import com.scality.osis.redis.service.ScalityRedisRepository;
@@ -404,6 +405,19 @@ public class BaseOsisServiceTest {
                 .withAccessKeyId(TEST_ACCESS_KEY)
                 .withCreateDate(new Date())
                 .withStatus(StatusType.Active)
+                .withUserName(request.getUserName());
+
+        return new ListAccessKeysResult()
+                .withAccessKeyMetadata(Collections.singletonList(accessKeyMetadata));
+    }
+
+    protected ListAccessKeysResult listInactiveAccessKeysMockResponse(final InvocationOnMock invocation) {
+        final ListAccessKeysRequest request = invocation.getArgument(0);
+
+        final AccessKeyMetadata accessKeyMetadata = new AccessKeyMetadata()
+                .withAccessKeyId(TEST_ACCESS_KEY)
+                .withCreateDate(new Date())
+                .withStatus(StatusType.Inactive)
                 .withUserName(request.getUserName());
 
         return new ListAccessKeysResult()

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -1,6 +1,7 @@
 package com.scality.osis.utils;
 
 import com.amazonaws.services.identitymanagement.model.*;
+import com.amazonaws.services.identitymanagement.model.User;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.scality.osis.model.*;

--- a/storage-platform-clients/build.gradle
+++ b/storage-platform-clients/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testCompile 'org.javaswift:joss:0.9.13'
     testCompile 'org.apache.httpcomponents:httpclient:4.5.2'
     testCompile 'ch.qos.logback:logback-classic:1.2.1'
-    implementation 'com.scality:vaultclient:0.4.0-SNAPSHOT'
+    implementation 'com.scality:vaultclient:0.5.0'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.11.914'
     implementation 'com.amazonaws:aws-java-sdk-sts:1.11.914'
     implementation 'com.amazonaws:aws-java-sdk-iam:1.11.914'

--- a/storage-platform-clients/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
+++ b/storage-platform-clients/src/main/java/com/scality/osis/vaultadmin/VaultAdmin.java
@@ -8,15 +8,7 @@ package com.scality.osis.vaultadmin;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
-import com.scality.vaultclient.dto.AccountData;
-import com.scality.vaultclient.dto.CreateAccountRequestDTO;
-import com.scality.vaultclient.dto.CreateAccountResponseDTO;
-import com.scality.vaultclient.dto.GenerateAccountAccessKeyRequest;
-import com.scality.vaultclient.dto.GenerateAccountAccessKeyResponse;
-import com.scality.vaultclient.dto.GetAccountRequestDTO;
-import com.scality.vaultclient.dto.ListAccountsRequestDTO;
-import com.scality.vaultclient.dto.ListAccountsResponseDTO;
-import com.scality.vaultclient.dto.UpdateAccountAttributesRequestDTO;
+import com.scality.vaultclient.dto.*;
 import com.scality.vaultclient.services.AccountServicesClient;
 import com.scality.vaultclient.services.SecurityTokenServicesClient;
 
@@ -122,4 +114,13 @@ public interface VaultAdmin {
    * @return The updated account as a create account response object.
    */
   CreateAccountResponseDTO updateAccountAttributes(UpdateAccountAttributesRequestDTO updateAccountAttributesRequestDTO);
+
+  /**
+   * Get User by accessKey
+   * <p>This method will get the User from Vault using a user accessKey.
+   *
+   * @param getUserByAccessKeyRequest the get user by accessKey request dto
+   * @return The get user by accessKey response object.
+   */
+  GetUserByAccessKeyResponseDTO getUserByAccessKey(GetUserByAccessKeyRequestDTO getUserByAccessKeyRequest);
 }

--- a/storage-platform-clients/src/main/java/com/scality/osis/vaultadmin/impl/VaultAdminImpl.java
+++ b/storage-platform-clients/src/main/java/com/scality/osis/vaultadmin/impl/VaultAdminImpl.java
@@ -379,4 +379,9 @@ public class VaultAdminImpl implements VaultAdmin{
   public CreateAccountResponseDTO updateAccountAttributes(UpdateAccountAttributesRequestDTO updateAccountAttributesRequestDTO) {
     return ExternalServiceFactory.executeVaultService(vaultAccountClient::updateAccountAttributes, updateAccountAttributesRequestDTO);
   }
+
+  @Override
+  public GetUserByAccessKeyResponseDTO getUserByAccessKey(GetUserByAccessKeyRequestDTO getUserByAccessKeyRequest) {
+    return ExternalServiceFactory.executeVaultService(vaultAccountClient::getUserByAccessKey, getUserByAccessKeyRequest);
+  }
 }


### PR DESCRIPTION
following [the VMware API documentation](https://developer.vmware.com/apis/1034#/s3credential/updateCredentialStatus)

but OSE doesn't send tenant_id and user_id params which are mandatory for activate/deactivate a user's credential, so we introduced a new super admin API in vault
reference PRs:
- https://github.com/scality/vaultclient/pull/406
- https://github.com/scality/vaultclient-java/pull/22
- https://github.com/scality/Vault/pull/2065


the workflow of updateCredentialStatus is as below:
![Untitled (1)](https://user-images.githubusercontent.com/89449437/185123824-81eff66f-12da-45df-ac84-01703900d650.svg)

