### PR TITLE
feature: OSIS-67 release 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ plugins {
 }
 
 group = 'com.scality'
-version '1.0.0'
 description = 'osis.scality'
 sourceCompatibility = '1.8'
 
@@ -100,6 +99,7 @@ sourceSets {
 }
 
 configure(allprojects) {
+    version = '1.1.0'
     ext {
         springBootVersion = '2.2.5.RELEASE'
     }
@@ -155,7 +155,6 @@ publishing {
         mavenJava(MavenPublication) {
             groupId 'com.scality'
             artifactId 'osis'
-            version '1.0.0'
 
             from components.java
 

--- a/osis-app/build.gradle
+++ b/osis-app/build.gradle
@@ -10,4 +10,3 @@ dependencies {
 }
 jar.enabled(true)
 group = 'com.scality'
-version '1.0.0'

--- a/osis-core/build.gradle
+++ b/osis-core/build.gradle
@@ -5,4 +5,3 @@ test {
     useJUnitPlatform()
 }
 group = 'com.scality'
-version '1.0.0'

--- a/osis-core/src/main/java/com/scality/osis/configuration/DocumentationConfig.java
+++ b/osis-core/src/main/java/com/scality/osis/configuration/DocumentationConfig.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class DocumentationConfig {
     private static final String DOC_TITLE = "Object Storage Interoperability Services API for Scality platform";
     private static final String DOC_DESCRIPTION = "This is VMware Cloud Director Object Storage Interoperability Services API for Scality platform.";
-    private static final String DOC_VERSION = "1.0.0";
+    private static final String DOC_VERSION = "1.1.0";
     private static final String PROJECT_BASE = "com.scality.osis";
 
     ApiInfo apiInfo() {

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -53,7 +53,7 @@ public final class ScalityTestUtils {
     public static final String TEST_S3_INTERFACE_URL = "https://localhost:8443";
     public static final String PLATFORM_NAME = "Scality";
     public static final String PLATFORM_VERSION = "7.10";
-    public static final String API_VERSION = "1.0.0";
+    public static final String API_VERSION = "1.1.0";
     public static final long SAMPLE_DURATION_SECONDS = 120L;
     public static final String ACTIVE_STR = "Active";
     public static final String NA_STR = "N/A";

--- a/storage-platform-clients/build.gradle
+++ b/storage-platform-clients/build.gradle
@@ -38,7 +38,6 @@ test {
 }
 
 group = 'com.scality'
-version = '1.0.0'
 description = 'storage-platform-clients'
 sourceCompatibility = '1.8'
 


### PR DESCRIPTION
removed version definition from each project file, but configure it [here](https://github.com/scality/osis/pull/101/files#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R102) for all projects

so that whenever we need to bump a version, no need to change the version everywhere