### PR TITLE
feature: OSIS-86 return cd_tenant_id in getCredential

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -681,7 +681,15 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 String secretKey = retrieveSecretKey(
                         ScalityModelConverter.toRepoKeyForCredentials(userId, accessKeyMetadata.getAccessKeyId()));
 
+                // get Osis User by userId
+                GetUserRequest getUserRequest = ScalityModelConverter.toIAMGetUserRequest(userId);
+                logger.debug("[Vault] Get User Request:{}", new Gson().toJson(getUserRequest));
+                GetUserResult getUserResult = iam.getUser(getUserRequest);
+                logger.debug("[Vault] Get User response:{}", new Gson().toJson(getUserResult));
+                OsisUser osisUser = ScalityModelConverter.toOsisUser(getUserResult.getUser(), tenantId);
+
                 OsisS3Credential osisCredential = ScalityModelConverter.toOsisS3Credentials(tenantId,
+                        osisUser.getCdTenantId(),
                         accessKeyMetadata,
                         secretKey);
                 logger.info("Get S3 credential  response:{}",

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -9,14 +9,6 @@ import com.amazonaws.services.identitymanagement.model.User;
 import com.amazonaws.services.identitymanagement.model.*;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
-import com.scality.vaultclient.dto.*;
-import com.scality.osis.model.OsisS3Credential;
-import com.scality.osis.model.OsisTenant;
-import com.scality.osis.model.OsisUser;
-import com.scality.osis.model.PageInfo;
-import com.scality.osis.model.PageOfS3Credentials;
-import com.scality.osis.model.PageOfTenants;
-import com.scality.osis.model.PageOfUsers;
 import com.scality.osis.model.*;
 import com.scality.osis.model.exception.BadRequestException;
 import com.scality.vaultclient.dto.*;
@@ -646,8 +638,10 @@ public final class ScalityModelConverter {
                 .immutable(Boolean.TRUE);
     }
 
-    public static OsisS3Credential toOsisS3Credentials(String tenantId, AccessKeyMetadata accessKeyMetadata,
-            String secretKey) {
+    public static OsisS3Credential toOsisS3Credentials(String tenantId,
+                                                       String cdTenantId,
+                                                       AccessKeyMetadata accessKeyMetadata,
+                                                       String secretKey) {
         OsisS3Credential s3Credential = new OsisS3Credential()
                 .accessKey(accessKeyMetadata.getAccessKeyId())
                 .active(accessKeyMetadata.getStatus()
@@ -655,6 +649,7 @@ public final class ScalityModelConverter {
                 .userId(accessKeyMetadata.getUserName())
                 .cdUserId(accessKeyMetadata.getUserName())
                 .tenantId(tenantId)
+                .cdTenantId(cdTenantId)
                 .creationDate(accessKeyMetadata.getCreateDate().toInstant())
                 .immutable(Boolean.TRUE)
                 .secretKey(StringUtils.isEmpty(secretKey) ? ScalityConstants.NOT_AVAILABLE : secretKey);

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -401,13 +401,18 @@ public class ScalityModelConverterTest {
                 .withUserName(TEST_USER_ID);
 
         // Run the test
-        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, accesskeyMetaData,
-                TEST_SECRET_KEY);
+        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(
+                TEST_TENANT_ID,
+                TEST_CD_TENANT_ID,
+                accesskeyMetaData,
+                TEST_SECRET_KEY
+        );
 
         // Verify the results
         assertEquals(TEST_USER_ID, result.getCdUserId());
         assertEquals(TEST_USER_ID, result.getUserId());
         assertEquals(TEST_TENANT_ID, result.getTenantId());
+        assertEquals(TEST_CD_TENANT_ID, result.getCdTenantId());
         assertEquals(TEST_ACCESS_KEY, result.getAccessKey());
         assertEquals(TEST_SECRET_KEY, result.getSecretKey());
         assertTrue(result.getActive());
@@ -424,13 +429,18 @@ public class ScalityModelConverterTest {
                 .withUserName(TEST_USER_ID);
 
         // Run the test
-        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(TEST_TENANT_ID, accesskeyMetaData,
-                null);
+        final OsisS3Credential result = ScalityModelConverter.toOsisS3Credentials(
+                TEST_TENANT_ID,
+                TEST_CD_TENANT_ID,
+                accesskeyMetaData,
+                null
+        );
 
         // Verify the results
         assertEquals(TEST_USER_ID, result.getCdUserId());
         assertEquals(TEST_USER_ID, result.getUserId());
         assertEquals(TEST_TENANT_ID, result.getTenantId());
+        assertEquals(TEST_CD_TENANT_ID, result.getCdTenantId());
         assertEquals(TEST_ACCESS_KEY, result.getAccessKey());
         assertEquals(NOT_AVAILABLE, result.getSecretKey());
         assertTrue(result.getActive());

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityTestUtils.java
@@ -37,6 +37,7 @@ public final class ScalityTestUtils {
     public static final String SAMPLE_SCALITY_USER_EMAIL = "user.name@osis.scality.com";
 
     public static final String TEST_TENANT_ID = "tenantId";
+    public static final String TEST_CD_TENANT_ID = "cdTenantId";
     public static final String TEST_STR = "value";
     public static final String NOT_IMPLEMENTED_EXCEPTION_ERR = "expected NotImplementedException";
     public static final String NULL_ERR = "Expected Value. Found Null";


### PR DESCRIPTION
missing cd_tenant_id in the returning OsisCredential instance for GetCredential API

after fixing this, we should be able to release [this part from Integrantion CI ](https://github.com/scality/Integration/blob/development/9.1/genericStaas/env/run_osis_tests.bash#L101)