### PR TITLE
feature: OSIS-88 getAnonymousUser

### DIFF
--- a/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
+++ b/osis-app/src/main/java/com/scality/osis/resource/ScalityOsisController.java
@@ -737,9 +737,8 @@ public class ScalityOsisController {
     }
 
     @GetMapping(value = "/api/v1/anonymous-user", produces = "application/json")
-    @NotImplement(name = ScalityOsisConstants.GET_ANONYMOUS_USER_API_CODE)
-    public OsisUser getAnonymousUser() {
-        throw new NotImplementedException();
+    public AnonymousUser getAnonymousUser() {
+        return this.osisService.getAnonymousUser();
     }
 
     @PostMapping(value = "/api/admin-apis", produces = "application/json")

--- a/osis-core/src/main/java/com/scality/osis/model/AnonymousUser.java
+++ b/osis-core/src/main/java/com/scality/osis/model/AnonymousUser.java
@@ -1,0 +1,43 @@
+/**
+ *Copyright 2020 VMware, Inc.
+ *Copyright 2022 Scality, Inc.
+ *SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class AnonymousUser {
+
+  private String id;
+  private String name;
+
+  public AnonymousUser id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  @ApiModelProperty(value = "anonymous user id")
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public AnonymousUser name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @ApiModelProperty(value = "anonymous user name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
@@ -71,4 +71,6 @@ public interface ScalityOsisService {
     PageOfOsisBucketMeta getBucketList(String tenantId, long offset, long limit);
 
     OsisUsage getOsisUsage(Optional<String> tenantId, Optional<String> userId);
+
+    AnonymousUser getAnonymousUser();
 }

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -1145,6 +1145,16 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
         return new OsisUsage();
     }
 
+    @Override
+    public AnonymousUser getAnonymousUser() {
+        logger.info("Get Anonymous User request received");
+        AnonymousUser anonymousUser = new AnonymousUser()
+                .id(ANONYMOUS_USER_ID)
+                .name(ANONYMOUS_USER_NAME);
+        logger.trace("Get Anonymous User response, {}", new Gson().toJson(anonymousUser));
+        return anonymousUser;
+    }
+
     /**
      * Gets credentials.
      *

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -127,4 +127,7 @@ public final class ScalityConstants {
 
     public static final long DEFAULT_MIN_OFFSET = 0l;
     public static final long DEFAULT_MAX_LIMIT = 1000l;
+
+    public static final String ANONYMOUS_USER_ID = "65a011a2-9cdf-8ec5-33ec-3d1ccaae921c";
+    public static final String ANONYMOUS_USER_NAME = "AnonymousUser";
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceUserTests.java
@@ -662,4 +662,15 @@ public class ScalityOsisServiceUserTests extends BaseOsisServiceTest {
         assertTrue(resUser.getActive());
     }
 
+    @Test
+    public void testGetAnonymousUser() {
+        // Setup
+
+        // Run the test
+        final AnonymousUser anonymousUser = scalityOsisServiceUnderTest.getAnonymousUser();
+
+        // Verify the results
+        assertEquals(anonymousUser.getId(), ANONYMOUS_USER_ID);
+        assertEquals(anonymousUser.getName(), ANONYMOUS_USER_NAME);
+    }
 }


### PR DESCRIPTION
this API is needed for OSE healthcheck route `/api/v1/core` 
after implementing this API, now the response of `https://192.168.198.12/api/v1/core` is like:
```
{
    "name": "Cloud Director Object Storage Extension",
    "description": "Object Storage Extension for VMware Cloud Director",
    "version": "2.1.1-19362139",
    "buildDate": "2022-02-15T10:24:38.725+00:00"
}
```