### PR TITLE
Improvement/osis 107 improve setup admin policy process

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -261,6 +261,20 @@ public final class ScalityModelConverter {
     }
 
     /**
+     * Creates DetachRolePolicyRequest dto for detaching admin policy to OSIS role
+     *
+     * @param policyArn the policy arn
+     * @param roleName  the OSIS role name
+     *
+     * @return the AttachRolePolicyRequest dto
+     */
+    public static DetachRolePolicyRequest toDetachAdminPolicyRequest(String policyArn, String roleName) {
+        return new DetachRolePolicyRequest()
+                .withPolicyArn(policyArn)
+                .withRoleName(roleName);
+    }
+
+    /**
      * Creates DeleteAccessKeyRequest dto
      *
      * @param accessKeyId the accesskeyId
@@ -365,12 +379,18 @@ public final class ScalityModelConverter {
                 .withDescription(toUserPolicyDescription(tenantId));
     }
 
+    public static DeletePolicyRequest toDeleteAdminPolicyRequest(String tenantId) {
+        return new DeletePolicyRequest()
+                .withPolicyArn(toAdminPolicyArn(tenantId));
+    }
+
     public static CreatePolicyVersionRequest toCreateAdminPolicyVersionRequest(String tenantId) {
         return new CreatePolicyVersionRequest()
                 .withPolicyArn(toAdminPolicyArn(tenantId))
                 .withPolicyDocument(DEFAULT_ADMIN_POLICY_DOCUMENT)
                 .withSetAsDefault(true);
     }
+
     public static AttachUserPolicyRequest toAttachUserPolicyRequest(String policyArn, String username) {
         return new AttachUserPolicyRequest()
                 .withPolicyArn(policyArn)


### PR DESCRIPTION
instead of creating a policy version for admin policy every time when admin policy changes, delete it and create a new admin policy.

one reason is that createPolicyVersion has maximum 5 limits, it could be reached and then will raise error
another reason is that admin policy in any case we don't allow users to change it manually, so whenever it's different than defined, just delete it and create a new one, there is no need to maintain the old policies.
