### PR TITLE
Improvement/osis 116 find a way to make create date field compatible with what v mware expected

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/model/OsisBucketMeta.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisBucketMeta.java
@@ -18,7 +18,7 @@ public class OsisBucketMeta {
 
   @Valid
   @NotNull
-  private Long creationDate;
+  private String creationDate;
 
   @NotNull
   private String userId;
@@ -28,7 +28,7 @@ public class OsisBucketMeta {
     return this;
   }
 
-  public OsisBucketMeta creationDate(Long creationDate) {
+  public OsisBucketMeta creationDate(String creationDate) {
     this.creationDate = creationDate;
     return this;
   }
@@ -56,11 +56,11 @@ public class OsisBucketMeta {
    * @return creationDate
   */
   @ApiModelProperty(required = true, value = "bucket creation date")
-  public Long getCreationDate() {
+  public String getCreationDate() {
     return creationDate;
   }
 
-  public void setCreationDate(Long creationDate) {
+  public void setCreationDate(String creationDate) {
     this.creationDate = creationDate;
   }
 

--- a/osis-core/src/main/java/com/scality/osis/model/OsisS3Credential.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisS3Credential.java
@@ -25,7 +25,7 @@ public class OsisS3Credential {
   private Boolean active;
 
   @Valid
-  private Long creationDate;
+  private String creationDate;
 
   private Boolean immutable;
 
@@ -93,7 +93,7 @@ public class OsisS3Credential {
     this.active = active;
   }
 
-  public OsisS3Credential creationDate(Long creationDate) {
+  public OsisS3Credential creationDate(String creationDate) {
     this.creationDate = creationDate;
     return this;
   }
@@ -103,11 +103,11 @@ public class OsisS3Credential {
    * @return creationDate
   */
   @ApiModelProperty(value = "S3 credential creation date")
-  public Long getCreationDate() {
+  public String getCreationDate() {
     return creationDate;
   }
 
-  public void setCreationDate(Long creationDate) {
+  public void setCreationDate(String creationDate) {
     this.creationDate = creationDate;
   }
 

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -645,7 +645,7 @@ public final class ScalityModelConverter {
                 .tenantId(tenantId)
                 .cdTenantId(cdTenantId)
                 .username(username)
-                .creationDate(Instant.now().toEpochMilli())
+                .creationDate(Instant.now().toString())
                 .immutable(Boolean.TRUE);
     }
 
@@ -661,7 +661,7 @@ public final class ScalityModelConverter {
                 .cdUserId(accessKeyMetadata.getUserName())
                 .tenantId(tenantId)
                 .cdTenantId(cdTenantId)
-                .creationDate(accessKeyMetadata.getCreateDate().toInstant().toEpochMilli())
+                .creationDate(accessKeyMetadata.getCreateDate().toInstant().toString())
                 .immutable(Boolean.TRUE)
                 .secretKey(StringUtils.isEmpty(secretKey) ? ScalityConstants.NOT_AVAILABLE : secretKey);
 
@@ -733,7 +733,7 @@ public final class ScalityModelConverter {
                     .cdUserId(accessKeyMetadata.getUserName())
                     .tenantId(tenant.getTenantId())
                     .cdTenantId(tenant.getCdTenantIds().get(0))
-                    .creationDate(accessKeyMetadata.getCreateDate().toInstant().toEpochMilli())
+                    .creationDate(accessKeyMetadata.getCreateDate().toInstant().toString())
                     .immutable(Boolean.TRUE);
             if (null != secretKeyMap.get(accessKeyMetadata.getAccessKeyId())) {
                 // If secret key is available, add credential object to the list
@@ -817,7 +817,7 @@ public final class ScalityModelConverter {
 
         return new OsisBucketMeta()
                 .name(bucket.getName())
-                .creationDate(bucket.getCreationDate().toInstant().toEpochMilli())
+                .creationDate(bucket.getCreationDate().toInstant().toString())
                 .userId(userId);
     }
 


### PR DESCRIPTION
field creationDate of classes OsisBucketMeta and OsisS3Credential has now type string representing a date formated with ISO-8601 standard