### PR TITLE
feature: OSIS-138-iam-support-osis-spec

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/model/Information.java
+++ b/osis-core/src/main/java/com/scality/osis/model/Information.java
@@ -117,6 +117,8 @@ public class Information {
     @Valid
     private List<String> storageClasses = null;
 
+    private boolean iam = true;
+
     public Information platformName(String platformName) {
         this.platformName = platformName;
         return this;
@@ -337,6 +339,25 @@ public class Information {
 
     public void setStorageClasses(List<String> storageClasses) {
         this.storageClasses = storageClasses;
+    }
+
+    /**
+     * @param iam true
+     * @return this
+     */
+    public Information iam(boolean iam) {
+        this.iam = iam;
+        return this;
+    }
+
+    /**
+     * Get IAM support
+     *
+     * @return true
+     */
+    @Schema(description = "IAM support")
+    public Boolean getIam() {
+        return iam;
     }
 }
 

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -78,6 +78,7 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         assertEquals(TEST_S3_URL, information.getServices().getS3(), "Invalid S3 URL");
         assertNotNull(information.getNotImplemented(), NULL_ERR);
         assertEquals(domain + IAM_PREFIX, information.getServices().getIam(), "Invalid IAM URL");
+        assertEquals(true, information.getIam(), "Invalid IAM support status");
 
     }
 
@@ -101,6 +102,7 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         assertEquals(TEST_S3_URL, information.getServices().getS3(), "Invalid S3 URL");
         assertNotNull(information.getNotImplemented(), NULL_ERR);
         assertEquals(domain + IAM_PREFIX, information.getServices().getIam(), "Invalid IAM URL");
+        assertEquals(true, information.getIam(), "Invalid IAM support status");
     }
 
     @Test


### PR DESCRIPTION
This new property will tell VMWare OSE that OSIS adapter supports
standard IAM authentication.