### PR TITLE
OSIS-99 changes responses for HeadTenant API

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
+++ b/osis-core/src/main/java/com/scality/osis/service/ScalityOsisService.java
@@ -24,7 +24,7 @@ public interface ScalityOsisService {
 
     OsisTenant getTenant(String tenantId);
 
-    boolean headTenant(String tenantId);
+    void headTenant(String tenantId);
 
     void deleteTenant(String tenantId, Boolean purgeData);
 


### PR DESCRIPTION
Changed responses for HEAD tenant API to 200 OK for successful queries and 404 Not Found for unsuccessful queries

Reference: https://developer.vmware.com/apis/1034#/tenant/headTenant
Current open API spec of HeadTenant API from VMware
```
paths:
  "/api/v1/tenants/{tenantId}":
    head:
      tags:
        - tenant
        - required
      summary: Check whether the tenant exists
      operationId: headTenant
      description: |
        Operation ID: headTenant<br>
        Check whether the tenant exists
      parameters:
        - in: path
          name: tenantId
          required: true
          description: Tenant ID to check on the platform
          schema:
            type: string
      responses:
        "200":
          description: The tenant exists
        "404":
          description: "The tenant doesn't exist"
```

Note to reviewers:
- tested with Vmware Vault and swagger spec from VMware