### PR TITLE
OSIS-134 update-vaultclient-java-to-v1.1.0-and parameters-consistency-for update-tenant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         osisVersion = '2.0.2'
-        vaultclientVersion = '1.0.0'
+        vaultclientVersion = '1.1.0'
         springBootVersion = '2.7.6'
     }
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
@@ -291,6 +291,34 @@ class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
     }
 
     @Test
+    void testUpdateTenantRequestParametersConsistencyForTenantID() {
+        final OsisTenant osisTenantReq = createSampleOsisTenantObj();
+        osisTenantReq.setTenantId(SAMPLE_ID + "1");
+
+        // Call Scality Osis service to update a tenant
+        final VaultServiceException exception = assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.updateTenant(SAMPLE_ID, osisTenantReq);
+        });
+
+        assertEquals(400, exception.getStatus().value());
+        assertEquals("E_BAD_REQUEST", exception.getErrorCode());
+    }
+
+    @Test
+    void testUpdateTenantRequestParametersConsistencyForName() {
+        final OsisTenant osisTenantReq = createSampleOsisTenantObj();
+        osisTenantReq.setTenantId(SAMPLE_TENANT_NAME + "1");
+
+        // Call Scality Osis service to update a tenant
+        final VaultServiceException exception = assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.updateTenant(SAMPLE_ID, osisTenantReq);
+        });
+
+        assertEquals(400, exception.getStatus().value());
+        assertEquals("E_BAD_REQUEST", exception.getErrorCode());
+    }
+
+    @Test
     void testGetTenant() {
         // Setup
 


### PR DESCRIPTION
This version of vaultlclient-java allows empty custom attributes to be passed via PatchTenant API  for UpdateAccountAttribute calls.
2nd commit ensures consistency of tenant ID and tenant Name for a bug in OSE where the PatchTenant request from VCD OSE can have name and ID of different storage accounts.