### PR TITLE
OSIS-137 add canonical ID as owner of buckets

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/model/OsisTenant.java
+++ b/osis-core/src/main/java/com/scality/osis/model/OsisTenant.java
@@ -21,6 +21,8 @@ public class OsisTenant {
     //  @NotNull
     private String tenantId;
 
+    private String canonicalId;
+
     private List<String> cdTenantIds;
 
     public OsisTenant active(boolean active) {
@@ -73,6 +75,30 @@ public class OsisTenant {
 
     public void setTenantId(String tenantId) {
         this.tenantId = tenantId;
+    }
+
+    /**
+     * tenant canonical id
+     * @param canonicalId
+     * @return
+     */
+    public OsisTenant canonicalId(String canonicalId) {
+        this.canonicalId = canonicalId;
+        return this;
+    }
+
+    /**
+     * tenant canonical id
+     *
+     * @return canonicalId
+     */
+    @Schema(description = "tenant canonical id", required = true, example = "4f6117a3fd3a4aca27000e4b1c518d28484115e5722beb3ce5f380583000531f")
+    public String getCanonicalId() {
+        return canonicalId;
+    }
+
+    public void setCanonicalId(String canonicalId) {
+        this.canonicalId = canonicalId;
     }
 
     public OsisTenant cdTenantIds(List<String> cdTenantIds) {

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityModelConverter.java
@@ -831,32 +831,33 @@ public final class ScalityModelConverter {
      * Converts S3 Bucket to OSIS bucket meta
      *
      * @param bucket S3 Bucket instance
+     * @param canonicalId canonicalId
      * @return the OSIS bucket meta
      */
-    public static OsisBucketMeta toOsisBucketMeta(Bucket bucket, String userId) {
+    public static OsisBucketMeta toOsisBucketMeta(Bucket bucket, String canonicalId) {
 
         return new OsisBucketMeta()
                 .name(bucket.getName())
                 .creationDate(bucket.getCreationDate().toInstant().toString())
-                .userId(userId);
+                .userId(canonicalId);
     }
 
     /**
      * Converts S3 list buckets response to OSIS page of bucket meta
      *
      * @param buckets the bucket list response
-     * @param userId userId
+     * @param canonicalId canonical ID
      * @param offset offset
      * @param limit limit
      * @return the OSIS page of bucket meta
      */
-    public static PageOfOsisBucketMeta toPageOfOsisBucketMeta(List<Bucket> buckets, String userId, long offset, long limit) {
+    public static PageOfOsisBucketMeta toPageOfOsisBucketMeta(List<Bucket> buckets, String canonicalId, long offset, long limit) {
         List<OsisBucketMeta> bucketItems = new ArrayList<>();
 
         List<Bucket> selectedBuckets = buckets.stream().skip(offset).limit(limit).collect(Collectors.toList());
 
         for (Bucket bucket : selectedBuckets) {
-            bucketItems.add(toOsisBucketMeta(bucket, userId));
+            bucketItems.add(toOsisBucketMeta(bucket, canonicalId));
         }
 
         PageInfo pageInfo = new PageInfo(limit, offset, (long) buckets.size());

--- a/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
@@ -343,7 +343,8 @@ class BaseOsisServiceTest {
                     final String accountArn = request.getAccountArn();
                     final String emailAddress = request.getEmailAddress() == null ? SAMPLE_SCALITY_ACCOUNT_EMAIL
                             : request.getEmailAddress();
-                    final String canonicalId = request.getCanonicalId() == null ? SAMPLE_ID : request.getCanonicalId();
+                    final String canonicalId = request.getCanonicalId() == null ? TEST_CANONICAL_ID
+                        : request.getCanonicalId();
                     final Map<String, String> customAttributestes = new HashMap<>();
                     customAttributestes.put(CD_TENANT_ID_PREFIX + SAMPLE_CD_TENANT_ID, "");
 
@@ -550,7 +551,7 @@ class BaseOsisServiceTest {
             final Bucket bucket = new Bucket();
             bucket.setName(TEST_BUCKET_NAME + (index));
             bucket.setCreationDate(new Date());
-            bucket.setOwner(new Owner(SAMPLE_TENANT_ID, SAMPLE_TENANT_NAME));
+            bucket.setOwner(new Owner(TEST_CANONICAL_ID, SAMPLE_TENANT_NAME));
 
             buckets.add(bucket);
         }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -128,6 +128,7 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
 
         // Verify the results
         assertEquals(TEST_BUCKET_TOTAL_NUMBER, response.getPageInfo().getTotal());
+        assertEquals(TEST_CANONICAL_ID, response.getItems().get(0).getUserId());
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
         assertEquals((int) limit, response.getItems().size());


### PR DESCRIPTION
Use Canonical ID for ownership of buckets as VMware now supports true IAM with OSIS 2.2.0.1