### PR TITLE
Improvement: osis 147 stop osis failure on decryption

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        osisVersion = '2.2.2'
+        osisVersion = '2.2.3'
         vaultclientVersion = '1.1.2'
         springBootVersion = '2.7.6'
     }

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -1406,14 +1406,19 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
         String secretKey = null;
 
         if (repoVal != null) {
+            try {
+                // Using `repoKey` for Associated Data during decryption
+                secretKey = cipherFactory.getCipherByID(repoVal.getKeyID())
+                        .decrypt(repoVal,
+                                cipherFactory.getSecretCipherKeyByID(repoVal.getKeyID()),
+                                repoKey);
 
-            // Using `repoKey` for Associated Data during encryption
-            secretKey = cipherFactory.getCipherByID(repoVal.getKeyID())
-                    .decrypt(repoVal,
-                            cipherFactory.getSecretCipherKeyByID(repoVal.getKeyID()),
-                            repoKey);
-
-            logger.debug("[Cache] Retrieve Secret Key successful");
+                logger.debug("[Cache] Retrieve Secret Key successful");
+            } catch (Exception e) {
+                logger.error("Error: Unable to decrypt secret key data for Redis key: {}. Error details: {}", repoKey, e.getMessage());
+                logger.debug("Full stack trace:", e);
+                deleteSecretKey(repoKey);
+            }
         }
         return secretKey;
     }


### PR DESCRIPTION
**Context:** VMware needs secret keys to be available on-demand which is contrary to AWS standard where secret keys are only shown at creation time. To achieve this OSIS stores any created access keys via OSIS in redis in AWS GCM in encrypted format. 

**Issue:** Due to [S3C-7645](https://scality.atlassian.net/browse/S3C-7645)  not being done, [an issue](https://scality.atlassian.net/browse/S3C-7406) occurs when doing a rolling deployment with new nodes on a cluster where OSIS is already enabled. This issue makes VMware cloud director UI un-usable by the end users.

The **resolution/changes** per discussion with product/customer/CS and Accounts team

This adds the capability of handling decryption failures for secret key data stored in Redis Sentinel using the method `retrieveSecretKey` used by the get and get credentials APIs.
- Does not throw any error for any decryption failure
- Logs all decryption failures
- Removes the keys from Redis automatically for any decryption failure,
  the keys remain in vault and can be used the user if secret key is
  accessible


**Note to reviewers:** We are fixing this in RING 9, for RING 8 we have a [TSKB](https://github.com/scality/tskb/pull/456) for internal CS and for customers as well: https://github.com/scality/tskb/pull/457

[S3C-7645]: https://scality.atlassian.net/browse/S3C-7645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ