### PR TITLE
VAULT-150: Add-S3C-7.10.9-branch-development/2.1-to-workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,9 +3,13 @@ name: codeQL
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - development/2.1
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - development/2.1
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -3,7 +3,9 @@ name: dependency review
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - development/2.1
 
 jobs:
   dependency-review:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -3,11 +3,15 @@ name: security
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - development/2.1
   release:
     types: [published]
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - development/2.1
   schedule:
     - cron: '0 8 * * 1' # Monday - 8am - UTC
   workflow_dispatch:


### PR DESCRIPTION
Adds development/2.1 used for RING 7.10.9 to workflows in the main as well.
Synthetic change for consistency, as development/2.1 already has the branch.