### PR TITLE
[Cherry-pick] Bugfix: OSIS-149 | Update error expectation from Assume Role Backbeat API and bump OSIS to 2.1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        osisVersion = '2.1.4'
+        osisVersion = '2.1.5'
         vaultclientVersion = '1.1.2'
         springBootVersion = '2.7.6'
     }

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -1249,10 +1249,9 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
         } catch (VaultServiceException e) {
 
             if (!StringUtils.isNullOrEmpty(e.getErrorCode()) &&
-                    NO_SUCH_ENTITY_ERR.equals(e.getErrorCode()) &&
-                    ROLE_DOES_NOT_EXIST_ERR.equals(e.getReason())) {
-                // If role does not exists, invoke setupAssumeRole
-                logger.error(ROLE_DOES_NOT_EXIST_ERR + ". Recreating the role");
+                    ACCESS_DENIED.equals(e.getErrorCode())) {
+                // if access denied, invoke setupAssumeRole
+                logger.error(e.getReason() + ". Recreating the role");
                 // Call get Account with Account ID to retrieve account name
                 AccountData account = vaultAdmin.getAccount(ScalityModelConverter.toGetAccountRequestWithID(accountID));
                 asyncScalityOsisService.setupAssumeRole(accountID, account.getName());

--- a/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
+++ b/osis-core/src/main/java/com/scality/osis/utils/ScalityConstants.java
@@ -56,9 +56,7 @@ public final class ScalityConstants {
 
     public static final String IAM_PREFIX = "/";
 
-    public static final String NO_SUCH_ENTITY_ERR = "NoSuchEntity";
-
-    public static final String ROLE_DOES_NOT_EXIST_ERR = "Role does not exist";
+    public static final String ACCESS_DENIED = "AccessDenied";
 
     public static final String NOT_AVAILABLE = "Not Available";
 

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -198,7 +198,7 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         // Setup
 
         when(vaultAdminMock.getTempAccountCredentials(any(AssumeRoleRequest.class)))
-                .thenThrow(new VaultServiceException(HttpStatus.NOT_FOUND, "NoSuchEntity", "Role does not exist"))
+                .thenThrow(new VaultServiceException(HttpStatus.FORBIDDEN, "AccessDenied", "User: backbeat is not allowed to assume role"))
                 .thenAnswer((Answer<Credentials>) invocation -> {
                     final Credentials credentials = new Credentials();
                     credentials.setAccessKeyId(TEST_ACCESS_KEY);


### PR DESCRIPTION
Cherry-picked from : https://github.com/scality/osis/pull/145/commits
For S3C 7.10.9
Main ticket: https://scality.atlassian.net/browse/S3C-8939