### PR TITLE
OSIS-154: Add Claude Code framework (CLAUDE.md, review skills, CI)

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: review-pr
+description: Review a PR on osis (Java 17 / Spring Boot control-plane adapter that bridges VMware Cloud Director OSE and Scality RING via Vault, S3, and Utapi)
+argument-hint: <pr-number-or-url>
+disable-model-invocation: true
+allowed-tools: Read, Bash(gh repo view *), Bash(gh pr view *), Bash(gh pr diff *), Bash(gh pr comment *), Bash(gh api *), Bash(git diff *), Bash(git log *), Bash(git show *)
+---
+
+# Review GitHub PR
+
+You are an expert code reviewer. Review this PR: $ARGUMENTS
+
+## Determine PR target
+
+Parse `$ARGUMENTS` to extract the repo and PR number:
+
+- If arguments contain `REPO:` and `PR_NUMBER:` (CI mode), use those values directly.
+- If the argument is a GitHub URL (starts with `https://github.com/`), extract `owner/repo` and the PR number from it.
+- If the argument is just a number, use the current repo from `gh repo view --json nameWithOwner -q .nameWithOwner`.
+
+## Output mode
+
+- **CI mode** (arguments contain `REPO:` and `PR_NUMBER:`): post inline comments and summary to GitHub.
+- **Local mode** (all other cases): output the review as text directly. Do NOT post anything to GitHub.
+
+## Steps
+
+1. **Fetch PR details:**
+
+```bash
+gh pr view <number> --repo <owner/repo> --json title,body,headRefOid,author,files
+gh pr diff <number> --repo <owner/repo>
+```
+
+2. **Read changed files** to understand the full context around each change (not just the diff hunks). For OSIS specifically:
+   - If the PR touches `osis-core/src/main/java/com/scality/osis/service/impl/*ServiceImpl.java`, also read the corresponding `storage-platform-clients/.../vaultadmin/impl/` or `s3/impl/` client. Service-level bugs almost always trace back to a Vault/S3 response shape.
+   - If the PR touches anything under `osis-core/.../security/`, also read `storage-platform-clients/.../security/crypto/` — the auth wiring and the at-rest crypto are intentionally split.
+   - `Design.md` and the diagrams under `Design_Files/` are the source of truth for `AssumeRole`, `SetupAssumeRole`, `markerCache`, and `assumeRoleCache` semantics. Cross-check behavior changes against them.
+
+3. **Analyze the changes** against these criteria:
+
+| Area | What to check |
+|------|---------------|
+| Generated code | `osis-core/src/main/java/com/scality/osis/App.java` is rewritten by the `app` Gradle task on every `compileJava`. Hand-edits to `VERSION` or `DATE` will be silently clobbered. Version bumps must change `osisVersion` in root `build.gradle:3`, not `App.java`. |
+| Module dependency direction | Strict: `osis-app → osis-core → storage-platform-clients`. Flag any new dependency that reverses this (e.g. a controller importing a client directly, or `osis-core` referencing `osis-app`). |
+| Spring patterns | `@Autowired` field injection vs constructor injection — prefer constructor injection for new beans. `@Async` methods must not call other `@Async` methods on the same bean (self-invocation bypasses the proxy). Bean scope changes are breaking. |
+| Exception handling | No swallowed exceptions (`catch (Exception e) {}` with no log/rethrow). Vault/S3/STS SDK errors should be mapped to the appropriate `OsisException` subtype in `model/exception/`, not leaked raw. `NoSuchEntity` from `AssumeRoleBackbeat` has a specific meaning (`Role does not exist` → run `SetupAssumeRole`); don't collapse it into a generic 500. |
+| Caching | The four caches (`markerCache`, `assumeRoleCache`, `listAccountsCache`, `accountIDCache`) are configured under `osis.scality.vault.cache.*`. Changes to TTLs, capacity, or cache keys need a reason — `assumeRoleCache` TTL is **50 minutes** because the session token is valid for 60. Going above 60 will break flows. |
+| Secret handling | Secret keys are encrypted via `osis.security.keys.cipher` (32-byte) and stored in Redis Sentinel hash `osis:s3credentials` keyed `<Username>__<AccessKeyID>`. Any change to the encryption path, key format, or hash schema is a data-migration concern. Never log secrets, access keys, or session tokens. |
+| AWS SDK usage | Region must come from config (`osis.scality.region`), not hardcoded. Credentials providers must use the `assumeRoleCache` for user-scoped calls, never super-admin creds for user-facing flows. STS session token refresh must use AWS SDK `refresh()` — don't roll your own. |
+| Dependency pinning | `vaultclientVersion`, `springBootVersion`, AWS SDK versions live in root `build.gradle`. Bumping any of these requires a coverage check and a Sonatype publish step; flag if the bump is unexplained. |
+| `application.properties` | The in-tree file is a **template**. Real values mount at `/conf/application.properties` in the container. Flag any commit that bakes in a non-default endpoint, real access key, or production hostname into the template. |
+| Test coverage | JaCoCo enforces **75% minimum** via `jacocoTestCoverageVerification`. New service/controller code without a corresponding test will likely drop coverage and fail `check`. Exclusion list in `jacoco.gradle:60-67` — don't expand it without a strong reason. |
+| Logging | Use SLF4J `Logger logger = LoggerFactory.getLogger(...)`. No `System.out.println`, no `printStackTrace()` in production code. Match log level to severity; `DEBUG` is fine, `ERROR` should mean operator-actionable. |
+| Health endpoints | Health is served at `/_/healthcheck`, not the Spring default. New health indicators belong in `osis-app/.../healthcheck/` and must extend `HealthIndicator`. Utapi healthcheck was intentionally removed in 2.2.5 — flag any attempt to re-add it without justification. |
+| Vendored crypto | `security/crypto/Hkdf*` is vendored from an external library and explicitly excluded from coverage and lint. Don't refactor it as if it were ours; flag any modification. |
+| OSE REST contract | OSE drives this service. Changes to request/response models in `osis-core/.../model/` (e.g. `OsisTenant`, `OsisUser`, `OsisS3Credential`, `Page*`) are potentially breaking for OSE consumers. Flag field renames, removals, or required-vs-optional flips. |
+| Security | OWASP-relevant: hard-coded credentials, SQL/log injection (no string-concatenated SQL or log args), path traversal in any file-read of `crypto.yml` or admin creds, secrets logged in error paths. |
+
+4. **Deliver your review:**
+
+### If CI mode: post to GitHub
+
+#### Part A: Inline file comments
+
+For each issue, post a comment on the exact file and line. Keep comments short (1-3 sentences), end with `— Claude Code`. Use line numbers from the **new version** of the file.
+
+**Without suggestion block** — single-line command, `<br>` for line breaks:
+```bash
+gh api -X POST -H "Accept: application/vnd.github+json" "repos/<owner/repo>/pulls/<number>/comments" -f body="Issue description.<br><br>— Claude Code" -f path="file" -F line=42 -f side="RIGHT" -f commit_id="<headRefOid>"
+```
+
+**With suggestion block** — use a heredoc (`-F body=@-`) so code renders correctly:
+```bash
+gh api -X POST -H "Accept: application/vnd.github+json" "repos/<owner/repo>/pulls/<number>/comments" -F body=@- -f path="file" -F line=42 -f side="RIGHT" -f commit_id="<headRefOid>" <<'COMMENT_BODY'
+Issue description.
+
+```suggestion
+first line of suggested code
+second line of suggested code
+```
+
+— Claude Code
+COMMENT_BODY
+```
+
+Only suggest when you can show the exact replacement. For architectural or design issues, just describe the problem.
+
+#### Part B: Summary comment
+
+Single-line command, `<br>` for line breaks. No markdown headings — they render as giant bold text. Flat bullet list only:
+
+```bash
+gh pr comment <number> --repo <owner/repo> --body "- file:line — issue<br>- file:line — issue<br><br>Review by Claude Code"
+```
+
+If no issues: just say "LGTM". End with: `Review by Claude Code`
+
+### If local mode: output the review as text
+
+Do NOT post anything to GitHub. Instead, output the review directly as text.
+
+For each issue found, output:
+
+```
+**<file_path>:<line_number>** — <what's wrong and how to fix it>
+```
+
+When the fix is a concrete line change, include a fenced code block showing the suggested replacement.
+
+At the end, output a summary section listing all issues. If no issues: just say "LGTM".
+
+End with: `Review by Claude Code`
+
+## What NOT to do
+
+- Do not comment on markdown formatting preferences
+- Do not suggest refactors unrelated to the PR's purpose
+- Do not praise code — only flag problems or stay silent
+- If no issues are found, post only a summary saying "LGTM"
+- Do not flag style issues already covered by the project's linter (SpotBugs, PMD) — but **do** flag if a change adds something that those linters would catch *if* the `com/scality/osis/**` PMD exclusion were lifted (since today's PMD coverage on Scality code is effectively zero per `pmd.gradle:20`)

--- a/.github/workflows/review-dependency-bump.yml
+++ b/.github/workflows/review-dependency-bump.yml
@@ -1,0 +1,19 @@
+name: Review Dependency Bump
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  review-dependency-bump:
+    # pr.user.login catches dependabot PRs updated by a human, where github.actor is no longer dependabot[bot].
+    if: github.actor == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: scality/workflows/.github/workflows/claude-code-dependency-review.yml@v2.8.3
+    with:
+      ACTIONS_APP_ID: ${{ vars.ACTIONS_APP_ID }}
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
+      CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
+      ACTIONS_APP_PRIVATE_KEY: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,14 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+jobs:
+  review:
+    uses: scality/workflows/.github/workflows/claude-code-review.yml@v2.8.3
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
+      CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this service is
+
+OSIS (Object Storage Interoperability Service) is the control-plane adapter that lets **VMware Cloud Director Object Storage Extension (OSE)** drive **Scality RING** for tenant/user/credential management. The data path stays between OSE and RING; OSIS only handles the control channel by translating OSE's REST contract into calls against Scality `Vault` (the Scality identity service, *not* HashiCorp Vault), S3, and Utapi.
+
+See `Design.md` for the full per-API design (it is the source of truth for flow semantics like `AssumeRole`, `SetupAssumeRole`, and the `markerCache` / `assumeRoleCache` behaviors).
+
+## Module layout
+
+Gradle multi-project (`settings.gradle`) with three submodules **plus a root `src/`** that ships the Spring Boot entry point:
+
+- `src/main/java/com/scality/osis/Application.java` — `@SpringBootApplication` main class. Referenced as `mainClass` in `build.gradle`'s `bootJar`. Not in any submodule.
+- `src/main/resources/` — runtime config templates: `application.properties`, `crypto.yml`, `s3capabilities.json`. In the container these are expected at `/conf/application.properties` and `/conf/crypto.yml` (mounted as volumes; see `Dockerfile` `ENTRYPOINT`).
+- `osis-app/` — REST controllers (`ScalityOsisController`) and Actuator health indicators (`S3HealthIndicator`, `VaultHealthIndicator`). Depends on `osis-core`.
+- `osis-core/` — business logic: `service/`, `configuration/`, `security/` (JWT + basic + platform auth), `redis/`, `model/`, `resource/` (capabilities + Jackson customizer), `validation/`. Depends on `storage-platform-clients`.
+- `storage-platform-clients/` — clients to Scality services: `vaultadmin/` (with `cache/`), `s3/`, `utapi/`, `utapiclient/`, plus `security/crypto/` for the secret-key encryption used to store credentials in Redis.
+
+Dependency direction is strictly `osis-app → osis-core → storage-platform-clients`. Don't introduce reverse edges.
+
+## Generated code: do not hand-edit
+
+`osis-core/src/main/java/com/scality/osis/App.java` holds `VERSION` and `DATE` constants. The Gradle `app` task (`build.gradle:111`) rewrites both on every `compileJava` from `osisVersion` in `build.gradle:3` and the current time. To bump the version, change `osisVersion`, not `App.java`.
+
+## Build, test, run
+
+All commands assume the repo root and Java 17.
+
+```sh
+./gradlew clean build                # full build incl. JaCoCo + SpotBugs + PMD
+./gradlew test                       # JUnit Platform tests (all modules)
+./gradlew :osis-core:test --tests 'FullyQualifiedClassName.methodName'   # single test
+./gradlew bootJar                    # executable jar at build/libs/osis-scality-<version>.jar
+./gradlew dependencyCheckAnalyze     # OWASP dependency-check; report in build/reports
+./gradlew spotbugsMain pmdMain       # static analysis (reports in reports/)
+./gradlew jacocoTestReport           # coverage report → reports/code-coverage
+```
+
+Run as a standalone JAR (dev only):
+```sh
+java -jar -Dserver.tomcat.basedir=tomcat -Dserver.tomcat.accesslog.directory=logs \
+     -Dserver.tomcat.accesslog.enabled=true \
+     build/libs/osis-scality-<version>.jar
+```
+
+Docker build/run is documented in `README.md`. The image expects three volume mounts: the PKCS#12 keystore at `/app/lib/osis.p12`, plus `/conf/application.properties` and `/conf/crypto.yml`.
+
+### Coverage gate
+
+JaCoCo enforces a **75% minimum** via `jacocoTestCoverageVerification` (`jacoco.gradle:75`), wired into `check`. Drops below 75% fail the build. The verification excludes config classes, the legacy VMware OSIS stub, and large chunks of `com/scality/osis/security/**` — re-check the exclusion lists in `jacoco.gradle` before assuming a class is covered.
+
+### PMD scope
+
+`pmd.gradle:20` currently **excludes all of `com/scality/osis/**`** with a `Needs to be removed` comment. New Scality code is not actually PMD-gated yet; if you're tightening lint coverage, remove that exclusion and expect work.
+
+## Architecture: the three flows you'll hit most
+
+1. **Tenant APIs** use **super-admin Vault credentials** directly. `create-account` / `list-accounts` / `get-account` / `delete-account` against Vault. `list-accounts` results are paginated via a short-lived `markerCache` (60s) keyed by `(max-limit + 1)`.
+2. **User and S3 credential APIs** require the **AssumeRole flow** first:
+   - Look up `accountID → temporary creds` in `assumeRoleCache` (TTL 50 minutes; session token is valid 60). On miss, call `AssumeRoleBackbeat` as super-admin.
+   - If that returns `NoSuchEntity / Role does not exist`, run the **`SetupAssumeRole` subroutine**: generate an account access key, create the `osis` role with the trust policy in `Design.md`, attach `adminPolicy@[account-id]` (full s3+iam), then delete the access key.
+   - User-side flows also lazily create `userPolicy@[account-id]` (full s3) the first time a user gets an access denied.
+3. **S3 credential storage**: secret keys are encrypted with the key from `crypto.yml` (`osis.security.keys.cipher`, 32-byte) and written to Redis Sentinel in the hash `osis:s3credentials` keyed by `<Username>__<AccessKeyID>`. The `storage-platform-clients/.../security/crypto` package owns the cipher.
+
+The caches (`markerCache`, `assumeRoleCache`, `listAccountsCache`, `accountIDCache`) are all configured under `osis.scality.vault.cache.*` in `application.properties`. Look here first when investigating staleness or memory issues.
+
+## Configuration surface
+
+`src/main/resources/application.properties` is the canonical reference for runtime knobs. Notable groups:
+
+- `osis.scality.vault.*` — Vault endpoint, super-admin keys, admin-creds decryption (`decrypt-admin-credentials=true` reads `admin-file-path` encrypted with `master-keyfile-path`), per-cache TTLs.
+- `osis.scality.s3.*` / `osis.scality.utapi.*` — endpoints + healthcheck timeouts. Utapi healthcheck was removed in 2.2.5 (see commit `682ecc3`).
+- `security.jwt.*` — JWT issuer, signing key, token TTLs. `security.jwt.enabled=false` by default; basic auth and platform auth live alongside under `osis-core/src/main/java/com/scality/osis/security/`.
+- `spring.redis.sentinel.*` — required; the secret-key store assumes Sentinel.
+- `management.endpoints.web.base-path=/_` and `management.endpoints.web.path-mapping.health=healthcheck` — health is served at `/_/healthcheck`, not the Spring default.
+
+## CI
+
+Workflows live under `.github/workflows/`:
+- `test-and-build.yml` — runs on every push outside `development/**`, `main/**`, `q/*/**`. Calls `docker-build.yml` and uploads coverage to Codecov. **The Gradle build step was removed in commit `ea0ab90` (OSIS-152)** — Gradle now only runs inside the Docker build.
+- `gradle-build-and-upload.yml` — invoked from `release.yml` (which is `workflow_dispatch`-only). Publishes signed snapshots/releases to Sonatype Nexus.
+- `codeql.yaml`, `security.yaml`, `dependency-review.yaml` — security scans on PRs.
+
+## When investigating a JIRA ticket against this repo
+
+Follow the evidence-first workflow in `~/.claude/CLAUDE.md`. Repo-specific pointers:
+- Bugs around tenant/user creation almost always trace to a Vault response — read the relevant `*ServiceImpl` in `osis-core/src/main/java/com/scality/osis/service/impl/` first, then the `vaultadmin` client implementation.
+- Credential / login issues split between `osis-core/.../security/` (auth wiring) and `storage-platform-clients/.../security/crypto/` (encryption at rest).
+- Caching-related bug? Confirm the relevant cache config in `application.properties` and the cache wrapper in `vaultadmin/impl/cache/` before suspecting business logic.
+- The `Design.md` activity diagrams (under `Design_Files/`) are usually still accurate; cross-check ticket text against them.
+
+## What not to do
+
+- Don't hand-edit `osis-core/.../App.java` (it is generated).
+- Don't add reverse-direction module deps (controllers → clients without going through core).
+- Don't commit `application.properties` changes that bake in non-default endpoints/keys — the in-tree file is a template; real values land via the `/conf/` mount or env file at deploy time.
+- The two encryption code paths (`security/crypto/Hkdf*`) are vendored from an external library and explicitly excluded from coverage/lint — don't refactor them as if they were ours.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Stack at a glance
+
+OSIS is a **Java 17 Spring Boot 2.7.6** service built with **Gradle 7** as a multi-module project. Expect:
+
+- `*.java` under `osis-app/`, `osis-core/`, `storage-platform-clients/`, and the root `src/main/java/`
+- `*.gradle` build scripts (root `build.gradle`, per-module, plus `jacoco.gradle` / `pmd.gradle` / `spotbugs.gradle` / `upload-artifact.gradle`)
+- `application.properties` and `crypto.yml` config templates under `src/main/resources/`
+- Internal Scality dep: `com.scality:vaultclient` (Maven-published, pinned via `vaultclientVersion` in root `build.gradle`)
+- External: AWS SDK (S3, STS, IAM), Spring Security + JWT, Spring Data Redis (Sentinel), SpringDoc OpenAPI
+
 ## What this service is
 
 OSIS (Object Storage Interoperability Service) is the control-plane adapter that lets **VMware Cloud Director Object Storage Extension (OSE)** drive **Scality RING** for tenant/user/credential management. The data path stays between OSE and RING; OSIS only handles the control channel by translating OSE's REST contract into calls against Scality `Vault` (the Scality identity service, *not* HashiCorp Vault), S3, and Utapi.


### PR DESCRIPTION
## Intent: why does this change exist?
Set up a repo-local Claude Code framework so future agent sessions start with accurate repo context and so PRs get an automated review pass. OSIS-154.

## System impact: what's affected, including downstream?
Adds `CLAUDE.md`, two `.claude/skills/` (review-pr, setup-review-dependency-bump), and two GitHub Actions workflows (`review.yml`, `review-dependency-bump.yml`). No application code, build, or runtime config touched.

## Preserved behavior: what explicitly stays the same?
Service behavior, build, tests, and existing CI (`test-and-build.yml`, `gradle-build-and-upload.yml`, security scans) are unchanged. Coverage gate, lint config, and module layout untouched.

## Intended change: what's different after this PR?
New PRs trigger an automated Claude review workflow, with a dedicated path for dependency bumps. `CLAUDE.md` documents the stack, module dependency direction, generated-file rules, and the AssumeRole / cache flows so agents stop rediscovering them.

## Verification: how do we know this worked, or how would we know if it didn't?
Content-only change — no build impact. The review workflows will exercise themselves on this PR; if they don't run or fail to post, that's the signal to fix the workflow wiring before merge.