### PR TITLE
OSIS-157: Add VCD-OSE lab skill with workflows, scripts, and Terraform

### DIFF
--- a/.claude/skills/vcd-ose-lab/SKILL.md
+++ b/.claude/skills/vcd-ose-lab/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: vcd-ose-lab
+description: Spin up, refresh, tear down, or troubleshoot a VMware Cloud Director + Object Storage Extension lab on AWS EC2 for OSIS development. The lab brings up VCD + OSE on Rocky 9 and wires them against externally-running OSIS/Vault/S3 (typically the engineer's local services, exposed via ngrok). Use when the user says "spin up VCD lab", "create OSE lab", "refresh OSE endpoints", "tear down VCD lab", "VCD lab status", "ssh to VCD lab", or describes a problem with the running lab.
+---
+
+<objective>
+Orchestrate a VMware Cloud Director + OSE lab for OSIS development. The skill IS the orchestrator: it drives AWS via Terraform, drives the VM via SSH into a shared remote tmux session, and uses the bash scripts under `dev/vcd-ose-lab/scripts/` as the canonical recipes for each phase.
+
+There is no `mage up`. Mage is used for two narrow concerns only:
+- `mage preflight` — agent-friendly prerequisite check with one actionable line per failure.
+- `mage tfvars` — render `configs/lab.yaml` into `terraform/terraform.tfvars`.
+
+Every other action is driven by this skill following one of the workflows below.
+</objective>
+
+<essential_principles>
+The lab is **stateful and expensive** (c5.4xlarge, ~$0.85/hr). Apply these rules:
+
+1. **Preflight first, always.** Run `mage preflight` before any action that touches AWS, SSH, or local services. If anything fails, surface the actionable line to the user verbatim. Do not try to fix prerequisites on the user's behalf — ask.
+
+2. **Use the shared remote tmux session `lab`.** All VM commands go through SSH → tmux send-keys to a session named `lab` on the VM. The user can `ssh -t rocky@<ip> 'tmux attach -t lab'` to watch live. Every command is mirrored to `/tmp/lab.log` on the VM. Do not bypass tmux — the user must be able to observe.
+
+3. **Capture state under `_capture/`.** After every meaningful change, update `_capture/session-state.local.md` (gitignored) with the live IDs and URLs. Everything under `_capture/` is local-only (gitignored except the README) — the committed ground truth is `references/install-sequence.md` and `references/troubleshooting.md`; update those if you hit new edge cases.
+
+4. **Use FQDN, never the IP, for URLs the browser sees.** VCD's cert SAN includes both, but the OS-level CA trust + CORS allowed-origin only line up reliably with FQDN. The browser hits VCD at `https://<FQDN>/provider` and OSE at `https://<FQDN>:8443`. `/etc/hosts` on the dev machine must map FQDN → private IP. Several workflows depend on this — do not silently fall back to the IP.
+
+5. **Surface secrets through `configs/lab.yaml`.** Never bake secrets into commands typed inline. The agent reads `lab.yaml` via the config loader, or instructs the user to fill in fields if missing.
+
+6. **Doc gaps are real.** Fourteen Confluence-doc deltas are baked into `references/install-sequence.md` and `references/troubleshooting.md` (the numbered `#N` markers). Read `references/troubleshooting.md` before fighting a symptom — odds are it's a known gotcha (Rocky 9 missing `initscripts`, OSE 3.0 EULA persistence, VCD sites table empty, CORS director URL mismatch, hardcoded `/conf/crypto.yml`).
+
+7. **The lab depends on the engineer's local OSIS/Vault/Cloudserver.** Those run on the dev machine, in three named tmux sessions, exposed via ngrok. If they are not running, no lab operation will fully succeed. See `references/local-services.md`.
+</essential_principles>
+
+<intake>
+Ask the user **only if their intent is ambiguous**. Otherwise route directly.
+
+What do you want to do?
+
+1. **Spin up a fresh lab** — provision the EC2 VM, install VCD + OSE, wire OSIS.
+2. **Refresh endpoints** — ngrok URLs changed; re-wire OSE against the new URLs.
+3. **Tear down** — `terraform destroy` and clean up local capture.
+4. **Status** — run `ose config validate` on the VM; show local + remote health.
+5. **SSH to the lab** — attach to the remote `lab` tmux session.
+6. **Run preflight** — check prerequisites without touching anything.
+7. **Troubleshoot a specific symptom** — load the troubleshooting reference and diagnose.
+</intake>
+
+<routing>
+| User intent | Workflow |
+|---|---|
+| "spin up", "create", "bring up", "provision" the lab | `workflows/spin-up.md` |
+| "refresh", "ngrok changed", "endpoints changed", "re-wire" | `workflows/refresh-endpoints.md` |
+| "tear down", "destroy", "delete the lab", "shut it down" | `workflows/tear-down.md` |
+| "status", "is the lab healthy", "what's the state", "config validate" | `workflows/status.md` |
+| "ssh", "attach", "open lab terminal" | `workflows/ssh-to-lab.md` |
+| "preflight", "check prereqs" | Run `cd dev/vcd-ose-lab && mage preflight`. Read output to user. |
+| Specific error message (e.g., "Failed to Start", "CORS error", "NullPointerException CryptoEnv") | Read `references/troubleshooting.md` and match against the symptom list before improvising. |
+
+After reading the workflow, follow it exactly, top to bottom.
+</routing>
+
+<reference_index>
+**References** (load only what the active workflow tells you to):
+
+- `references/local-services.md` — How to run Vault + Cloudserver + OSIS locally (Mac or Linux) in tmux sessions + Redis sentinels + ngrok config. Loaded by spin-up and refresh-endpoints workflows.
+- `references/install-sequence.md` — The verified install sequence on the VM, phase by phase, with every interactive prompt and its expected response. Loaded by spin-up.
+- `references/troubleshooting.md` — known gotchas as "if you see X, do Y" entries, numbered to match the `#N` doc-gap markers in `install-sequence.md`. Loaded on any failure.
+- `references/session-state-template.md` — Template for `_capture/session-state.local.md`. Spin-up writes a fresh copy; refresh-endpoints updates the URLs section.
+
+**Scripts** (executed remotely via SCP + bash, or locally on the dev machine as noted):
+
+- `scripts/vm/postgres-setup.sh` — initdb, pg_hba rewrite, postgresql.conf patches, start+enable, create roles + DBs, set osedb collation.
+- `scripts/vm/install-vmware-vcd-systemd-unit.sh` — write `/etc/systemd/system/vmware-vcd.service`, daemon-reload, enable. Required because the VCD installer skips this on Rocky 9.
+- `scripts/vm/fix-vcd-public-urls.sh` — `UPDATE sites SET` to populate `rest_api_endpoint`, `base_ui_endpoint`, `multisite_url`, `name` with the FQDN. Without this, `https://<vm>/provider` returns "Failed to Start".
+- `scripts/vm/build-pkcs12-from-vcd-cert.sh` — `openssl pkcs12` with `-passin` and `-name <FQDN>`. The doc's command omits `-passin` (prompts for passphrase) and `-name <IP>` (breaks browser trust later).
+- `scripts/vm/wire-osis.sh` — `ose osis admin set` + `ose osis s3 set` + `ose platforms enable` + `ose service restart`. Used by both spin-up and refresh-endpoints.
+- `scripts/local/lib/platform.sh` — shared bash helpers (`detect_os`, `detect_java17_home`, `ngrok_config_path`, `package_install_hint`, `ca_trust_commands`) sourced by other local scripts. Handles Mac (Homebrew) and Linux (Debian + RHEL families).
+- `scripts/local/setup-redis-sentinels.sh` — Start three Redis sentinels (26379/80/81) monitoring localhost:6379. Required by OSIS (it hardcodes sentinel mode).
+- `scripts/local/build-osis-jar.sh` — Gradle build of OSIS with auto-discovered Java 17 + stub publish creds.
+</reference_index>
+
+<success_criteria>
+The skill has done its job when, after the active workflow:
+
+- For spin-up: `ose config validate` on the VM shows all seven rows `Valid`, and the user reports the VCD provider UI loads cleanly at the FQDN with no CORS errors clicking into Object Storage.
+- For refresh-endpoints: `ose config validate` shows all rows `Valid` again with the new URLs in `_capture/session-state.local.md`.
+- For tear-down: `terraform state list` is empty and the AWS console shows the instance and any lab-managed resources gone.
+- For status / ssh / preflight: the user has the information they asked for, with no side effects on the lab.
+
+Any failure surfaces a specific next-step instruction to the user, never a stack trace alone.
+</success_criteria>

--- a/.claude/skills/vcd-ose-lab/references/install-sequence.md
+++ b/.claude/skills/vcd-ose-lab/references/install-sequence.md
@@ -1,0 +1,171 @@
+# Install sequence (Rocky 9 + VCD 10.5 + OSE 3.0)
+
+Distilled from the manual ride-along of 2026-05-28 — every line here was verified end-to-end. Where the Confluence doc differs, the doc-gap number in parentheses points at the matching entry in `references/troubleshooting.md`.
+
+All commands assume you are root in the remote `lab` tmux session.
+
+Placeholders like `<postgres_password>` and `<vcd_cert_passphrase>` come from `configs/lab.yaml` (`mage preflight` fails if they're unset). Never substitute literal example passwords.
+
+## Phase 3 — OS bootstrap
+
+```bash
+sed -i 's/^.*ssh-rsa/ssh-rsa/' ~/.ssh/authorized_keys           # for direct-root-ssh later (cosmetic)
+dnf update -y
+dnf module enable postgresql:15 -y                              # (#1: not :13 on Rocky 9)
+dnf install -y vim nc bind bind-utils net-tools \
+    postgresql-server jq initscripts                            # (#6: initscripts required)
+```
+
+## Phase 3b — PostgreSQL
+
+Run `PG_PASSWORD='<postgres_password>' bash scripts/vm/postgres-setup.sh` (the password is required via env; the script quotes it safely server-side). Equivalent steps:
+
+```bash
+postgresql-setup --initdb
+# Write the local-only pg_hba.conf (peer for unix socket, scram-sha-256 for loopback)
+# Patch postgresql.conf: listen_addresses='localhost', max_connections=300, superuser_reserved_connections=90
+systemctl start postgresql && systemctl enable postgresql
+
+sudo -u postgres psql <<'SQL'
+create user vcdadmin with password '<postgres_password>' login;
+create user oseadmin with password '<postgres_password>' login;
+create database vcddb owner vcdadmin;
+create database osedb owner oseadmin lc_collate 'C' lc_ctype 'C' template template0;
+SQL
+```
+
+(#5: send SQL via `psql <<'SQL'` heredoc in a script, not via `tmux send-keys` — single quotes get mangled.)
+
+## Phase 4 — VCD install
+
+```bash
+chmod u+x /root/vmware-vcloud-director-distribution-*.bin
+printf 'y\nn\n' | /root/vmware-vcloud-director-distribution-*.bin
+```
+
+Expect a non-fatal `/bin/ln: failed to create symbolic link '/etc/init.d/'`. The RPMs install successfully but no systemd unit is created (#6).
+
+## Phase 5 — VCD configure
+
+```bash
+export HOST_IP=$(hostname -I | awk '{print $1}')
+export FQDN=$(hostname -f)
+
+cd /opt/vmware/vcloud-director/
+/opt/vmware/vcloud-director/bin/cell-management-tool generate-certs \
+    --cert cert.pem --key cert.key --key-password '<vcd_cert_passphrase>'
+
+/opt/vmware/vcloud-director/bin/configure \
+  --cert /opt/vmware/vcloud-director/cert.pem \
+  --key /opt/vmware/vcloud-director/cert.key \
+  --key-password '<vcd_cert_passphrase>' \
+  --primary-ip $HOST_IP \
+  --primary-port-http 80 \
+  --primary-port-https 443 \
+  --database-type postgres \
+  --database-host localhost \
+  --database-port 5432 \
+  --database-name vcddb \
+  --database-user vcdadmin \
+  --database-password '<postgres_password>' \
+  --enable-ceip false \
+  --unattended-installation
+```
+
+Expect a non-fatal `/sbin/chkconfig: No such file or directory` (#7). Then install the systemd unit:
+
+```bash
+bash /tmp/install-vmware-vcd-systemd-unit.sh
+systemctl start vmware-vcd
+```
+
+Wait for `Cell startup completed` in `/opt/vmware/vcloud-director/logs/cell.log` (~110 seconds).
+
+Then `system-setup` with stdin piped:
+
+```bash
+printf "<vcd_admin_password>\n<vcd_admin_password>\nY\n" | \
+  /opt/vmware/vcloud-director/bin/cell-management-tool system-setup \
+  --user admin \
+  --full-name "VCD System Administrator" \
+  --email vcd-admin@scality.lab \
+  --system-name VCD \
+  --installation-id 2
+```
+
+Then populate the `sites` table so the H5 UI works (#9), and restart:
+
+```bash
+bash /tmp/fix-vcd-public-urls.sh
+# scripts/vm/fix-vcd-public-urls.sh runs UPDATE sites SET rest_api_endpoint=...
+# and restarts vmware-vcd
+```
+
+## Phase 6 — OSE install
+
+```bash
+cd /root && dnf install -y ./vmware-ose-*.rpm
+echo accept | ose -h                       # (#11: persists EULA to /opt/vmware/voss/agreement)
+```
+
+## Phase 7 — OSE configure
+
+```bash
+CERT_PASSPHRASE='<vcd_cert_passphrase>' bash /tmp/build-pkcs12-from-vcd-cert.sh
+# (#10: includes -passin via env:CERT_PASSPHRASE; #13: FQDN friendly name)
+
+ose db set --url jdbc:postgresql://localhost:5432/osedb \
+           --user oseadmin --secret '<postgres_password>'
+```
+
+`ose director set` must be **interactive** (#11): pipe the password, then send `y` for trust-cert separately.
+
+```bash
+ose director set --url https://$FQDN --user admin@system
+# at "Secret :" → type <vcd_admin_password>
+# at "Do you trust this certificate for the SSL connection?" → y
+```
+
+```bash
+ose endpoint set --region=us-east-1 --url=https://$FQDN:8443
+ose ui install
+```
+
+## Phase 8 — OSIS wiring
+
+```bash
+ose osis admin set --name scality --url <osis_ngrok_url> --user <access_key>
+# at "Secret :" → type <secret_key>
+# at "password does not meet the complexity criteria" → y
+
+ose osis s3 set --name scality --url <s3_ngrok_url>
+ose platforms enable osis --name scality
+ose args set -k server.port -v 8443
+systemctl start voss-keeper
+ose service restart
+ose config validate
+```
+
+Expect all seven rows `Valid`.
+
+## Phase 9 — Dev-machine cert trust + /etc/hosts
+
+User-side commands (the agent prints, doesn't execute — they need sudo on the user's box). Use `ca_trust_commands` from `scripts/local/lib/platform.sh` to emit the correct form for the detected OS.
+
+Common steps (all platforms):
+
+```bash
+echo "<private_ip>  <FQDN>" | sudo tee -a /etc/hosts
+ssh -i <key> rocky@<private_ip> 'sudo cp /opt/vmware/vcloud-director/cert.pem /tmp/vcd-cert.pem && sudo chmod 644 /tmp/vcd-cert.pem'
+scp -i <key> rocky@<private_ip>:/tmp/vcd-cert.pem ~/Downloads/vcd-lab.pem
+```
+
+Then **one** of the following:
+
+- **Mac:** `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/Downloads/vcd-lab.pem`
+- **Debian/Ubuntu:** `sudo cp ~/Downloads/vcd-lab.pem /usr/local/share/ca-certificates/vcd-lab.crt && sudo update-ca-certificates`
+- **Fedora/Rocky/RHEL:** `sudo cp ~/Downloads/vcd-lab.pem /etc/pki/ca-trust/source/anchors/vcd-lab.pem && sudo update-ca-trust`
+
+After that `https://<FQDN>/provider` works in the browser, and More → Object Storage loads without CORS or trust errors.
+
+Firefox on Linux maintains its own NSS trust store — if the user opens VCD in Firefox they also need to import the PEM under Settings → Privacy & Security → View Certificates → Import. Chrome/Chromium reads the system NSS DB so the steps above are enough for those browsers.

--- a/.claude/skills/vcd-ose-lab/references/local-services.md
+++ b/.claude/skills/vcd-ose-lab/references/local-services.md
@@ -1,0 +1,203 @@
+# Running Vault, Cloudserver, and OSIS locally
+
+The VCD-OSE lab's OSE instance on EC2 needs to reach an OSIS, an S3, and a Vault somewhere. For development, the typical Scality engineer runs all three locally on their dev machine (Mac or Linux), then exposes them via ngrok so the EC2 VM can reach them.
+
+This doc walks the user through standing those three up in separate tmux sessions so each service's logs stay visible and each can be restarted independently. Where commands differ across operating systems, both forms are shown side by side; otherwise everything is portable.
+
+> Do **not** commit your local copy of this file with real credentials filled in. The version in the skill is the template; your working copy lives under `/tmp/osis-local/` (or wherever you choose).
+
+## Prerequisites
+
+- The three Scality repos cloned locally. Set `VAULT_REPO`, `CLOUDSERVER_REPO`, `OSIS_REPO` to where you cloned them; the snippets below use those variables. Example layout:
+  - `$VAULT_REPO` → `~/scality/vault`
+  - `$CLOUDSERVER_REPO` → `~/scality/cloudserver`
+  - `$OSIS_REPO` → `~/scality/osis`
+- Each repo's `yarn install` (or `./gradlew bootJar` for osis) has been run successfully at least once.
+- `tmux`, `redis`, JDK 17, `ngrok`, `terraform`, `jq` installed.
+  - **Mac:** `brew install tmux redis openjdk@17 ngrok terraform jq`
+  - **Debian/Ubuntu:** `sudo apt install tmux redis-server openjdk-17-jdk jq`; follow https://developer.hashicorp.com/terraform/install#linux for the HashiCorp apt repo, then `sudo apt install terraform`; follow https://ngrok.com/download for the `.deb` package.
+  - **Fedora/Rocky/RHEL:** `sudo dnf install tmux redis java-17-openjdk-devel jq`; `sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && sudo dnf install terraform`; ngrok via https://ngrok.com/download `.rpm`.
+- Redis available on `localhost:6379`, plus three Redis Sentinels on `26379/26380/26381` monitoring `mymaster` at `127.0.0.1:6379` (see `Sentinel setup` below). `scripts/local/setup-redis-sentinels.sh` handles this on any platform that has `redis-sentinel`.
+
+## Start the three sessions
+
+Run once at the start of each work session. The commands kill any stale tmux sessions of the same name and start fresh ones in detached mode, so they survive your terminal closing.
+
+`JAVA_HOME` is auto-discovered via `scripts/local/lib/platform.sh::detect_java17_home`, which prefers `$JAVA_HOME` if you have one set, then falls back to Homebrew on Mac and `/usr/lib/jvm/java-17-*` on Linux.
+
+```bash
+. dev/vcd-ose-lab/scripts/local/lib/platform.sh
+
+# Clean slate
+tmux kill-session -t vault       2>/dev/null
+tmux kill-session -t cloudserver 2>/dev/null
+tmux kill-session -t osis        2>/dev/null
+tmux kill-session -t ngrok       2>/dev/null
+
+# Vault
+tmux new-session -d -s vault       -x 200 -y 50
+tmux send-keys -t vault \
+  "cd $VAULT_REPO && VAULT_DB_BACKEND=LEVELDB yarn start" Enter
+
+# Cloudserver (S3)
+tmux new-session -d -s cloudserver -x 200 -y 50
+tmux send-keys -t cloudserver \
+  "cd $CLOUDSERVER_REPO && S3VAULT=scality REMOTE_MANAGEMENT_DISABLE=1 yarn start" Enter
+
+# OSIS — resolve the built jar from the repo so the version (osisVersion in
+# build.gradle, currently appended with -SNAPSHOT) never has to be hard-coded.
+# Newest jar wins, so a rebuild after a version bump is picked up automatically.
+OSIS_JAR="$(ls -t "$OSIS_REPO"/build/libs/osis-scality-*.jar | head -1)"
+tmux new-session -d -s osis        -x 200 -y 50
+tmux send-keys -t osis \
+  ". $OSIS_REPO/dev/vcd-ose-lab/scripts/local/lib/platform.sh && \
+   export JAVA_HOME=\$(detect_java17_home) && \
+   export PATH=\$JAVA_HOME/bin:\$PATH && \
+   cd /tmp/osis-local && \
+   java -jar -Dspring.config.location=file:/tmp/osis-local/application.properties \
+        $OSIS_JAR" Enter
+```
+
+(If `$OSIS_JAR` comes up empty, the jar hasn't been built yet — run `scripts/local/build-osis-jar.sh` first.)
+
+## Attach / detach / list / kill
+
+```bash
+tmux ls                    # list sessions
+tmux attach -t vault       # attach (Ctrl-b d to detach)
+tmux attach -t cloudserver
+tmux attach -t osis
+tmux kill-session -t osis  # stop one
+```
+
+`Ctrl-b d` detaches without killing. The process keeps running. Re-attach any time.
+
+## Verify each service is up
+
+```bash
+# Vault admin
+curl -s http://localhost:8600/_/healthcheck
+
+# Cloudserver (returns 405 for GET / which is expected)
+curl -sI http://localhost:8000/ | head -1
+
+# OSIS
+curl -s http://localhost:9333/_/healthcheck | python3 -m json.tool
+curl -s http://localhost:9333/api/info     | python3 -m json.tool
+```
+
+A healthy OSIS healthcheck shows all components `UP`:
+
+```json
+{
+  "status": "UP",
+  "components": {
+    "diskSpace": { "status": "UP" },
+    "ping":      { "status": "UP" },
+    "redis":     { "status": "UP" },
+    "s3":        { "status": "UP" },
+    "vault":     { "status": "UP" }
+  }
+}
+```
+
+## Sentinel setup (one-time)
+
+OSIS hardcodes Redis Sentinel mode. Run `scripts/local/setup-redis-sentinels.sh` once and the sentinels survive across runs (until a reboot of your dev machine). The script writes per-sentinel configs under `/tmp/osis-local/sentinels/` and daemonises `redis-sentinel` on 26379/26380/26381.
+
+If you'd rather do it by hand:
+
+```bash
+mkdir -p /tmp/osis-local/sentinels
+for p in 26379 26380 26381; do
+  cat > /tmp/osis-local/sentinels/sentinel-$p.conf <<EOF
+port $p
+dir /tmp/osis-local/sentinels
+pidfile /tmp/osis-local/sentinels/sentinel-$p.pid
+logfile /tmp/osis-local/sentinels/sentinel-$p.log
+sentinel monitor mymaster 127.0.0.1 6379 2
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 60000
+sentinel parallel-syncs mymaster 1
+EOF
+  redis-sentinel /tmp/osis-local/sentinels/sentinel-$p.conf --daemonize yes
+done
+for p in 26379 26380 26381; do echo -n "sentinel $p: "; redis-cli -p $p ping; done
+```
+
+## OSIS local config
+
+The OSIS jar reads its config from `/tmp/osis-local/application.properties`. A working dev copy with these overrides:
+
+- `osis.scality.vault.decrypt-admin-credentials=false` (use the plain access/secret keys, not the encrypted-on-disk variant).
+- `osis.scality.vault.access-key=<your-vault-dev-access-key>` and `secret-key=<your-vault-dev-secret-key>` — the values that match whatever the Vault you're running recognises as super-admin. For a fresh `VAULT_DB_BACKEND=LEVELDB` Vault these are documented in the Vault repo's dev README; do not paste them into this file.
+- `server.port=9333`, `server.ssl.enabled=false`.
+- `spring.redis.sentinel.master=mymaster`, `spring.redis.sentinel.nodes=localhost:26379,localhost:26380,localhost:26381`.
+- `osis.scality.s3.capabilities-file-path=file:$OSIS_REPO/src/main/resources/s3capabilities.json`.
+- `osis.api.version=1.0.0` and `osis.scality.redis.credentials.hashKey=osis:s3credentials` (these are required even if you don't think you need them — Spring fails fast on missing placeholders).
+
+`crypto.yml` is hardcoded to `file:/conf/crypto.yml` (see `CryptoEnv.java`). Place the file once on your dev box:
+
+```bash
+sudo mkdir -p /conf
+sudo cp /tmp/osis-local/crypto.yml /conf/crypto.yml
+sudo chmod 644 /conf/crypto.yml
+```
+
+Build the jar with `scripts/local/build-osis-jar.sh` (auto-discovers Java 17 on any platform). If you'd rather invoke gradle yourself:
+
+```bash
+. $OSIS_REPO/dev/vcd-ose-lab/scripts/local/lib/platform.sh
+export JAVA_HOME="$(detect_java17_home)"
+cd "$OSIS_REPO"
+./gradlew bootJar -x test -PsonatypeUsername=x -PsonatypePassword=x
+```
+
+## Expose to the EC2 lab via ngrok
+
+Once all three healthchecks are green, expose OSIS and S3 publicly so the OSE service on the EC2 VM can reach them. Vault stays local — only OSIS calls Vault.
+
+The ngrok config path differs per OS. `scripts/local/lib/platform.sh::ngrok_config_path` returns the right one:
+
+- **Mac:** `~/Library/Application Support/ngrok/ngrok.yml`
+- **Linux:** `~/.config/ngrok/ngrok.yml`
+
+```yaml
+# in the path above
+version: "3"
+agent:
+  authtoken: <your-token>
+tunnels:
+  osis:
+    proto: http
+    addr: 9333
+  s3:
+    proto: http
+    addr: 8000
+```
+
+Run it in a tmux session named `ngrok` — the spin-up/status/tear-down workflows all expect that session to exist alongside `vault`, `cloudserver`, and `osis`:
+
+```bash
+tmux kill-session -t ngrok 2>/dev/null
+tmux new-session -d -s ngrok -x 200 -y 50
+tmux send-keys -t ngrok "ngrok start --all" Enter
+```
+
+Copy the two public URLs that ngrok prints into `dev/vcd-ose-lab/configs/lab.yaml`:
+
+```yaml
+endpoints:
+  osis_url: https://<random>.ngrok-free.app
+  s3_url:   https://<random>.ngrok-free.app
+```
+
+Then run the `refresh-endpoints` workflow to re-wire OSE's OSIS adapter against the current URLs.
+
+## Common gotchas
+
+- `lsof -iTCP:8000,8500,8600,9333 -sTCP:LISTEN` shows nothing → one of the three tmux services died. Attach and read the logs.
+- `osis-scality-*.jar` not found → run `scripts/local/build-osis-jar.sh`; output lands in `build/libs/`.
+- OSIS log `Cannot invoke "...RedisProperties$Sentinel.getMaster()" because ... null` → you launched OSIS before the sentinels were running. Start sentinels, retry.
+- OSIS log `Could not resolve placeholder 'osis.scality.utapi.endpoint'` → missing line in `application.properties`; copy from this doc.
+- Cloudserver fails with `EADDRINUSE` on 8000 → kill the stale node process (`lsof -iTCP:8000 -sTCP:LISTEN`, then `kill <pid>`). The Docker proxy on 8000 from a `kind` cluster does NOT conflict; it maps to a container.

--- a/.claude/skills/vcd-ose-lab/references/session-state-template.md
+++ b/.claude/skills/vcd-ose-lab/references/session-state-template.md
@@ -1,0 +1,56 @@
+# Session state (template)
+
+Copy this template to `dev/vcd-ose-lab/_capture/session-state.local.md` (gitignored via `_capture/*`) at the end of a `spin-up` workflow, and update the URL block on every `refresh-endpoints`.
+
+```markdown
+# Live session state (local, gitignored)
+
+Date: <YYYY-MM-DD>
+
+## EC2 lab
+
+| | |
+|---|---|
+| Instance | `<instance_id>` |
+| Private IP | `<private_ip>` |
+| FQDN | `ip-<a>-<b>-<c>-<d>.<region>.compute.internal` |
+| Region | `<region>` |
+| AMI | `<ami_id>` |
+| Key | `<key_path>` |
+| SSH | `ssh -i <key> rocky@<ip>` |
+| Remote tmux | `ssh -i <key> -t rocky@<ip> 'tmux attach -t lab'` |
+| VCD provider UI | `https://<FQDN>/provider` (admin / <vcd_admin_password>) |
+| OSE endpoint | `https://<FQDN>:8443` |
+| VCD admin user | `admin@system` |
+| Cert passphrase | `<vcd_cert_passphrase>` (from `lab.yaml`; never record the real value here) |
+
+Dev machine /etc/hosts:
+```
+<private_ip>  <FQDN>
+```
+
+## Local dev services (tmux sessions)
+
+| Session | Service | Port | Attach |
+|---|---|---|---|
+| `vault` | Vault | 8500, 8600 | `tmux attach -t vault` |
+| `cloudserver` | S3 | 8000 | `tmux attach -t cloudserver` |
+| `osis` | OSIS (Java) | 9333 | `tmux attach -t osis` |
+| `ngrok` | ngrok | 4040 | `tmux attach -t ngrok` |
+
+Redis sentinels (daemonized): 26379, 26380, 26381.
+
+## ngrok tunnels (change every restart)
+
+| | |
+|---|---|
+| OSIS public URL | `<osis_ngrok_url>` → localhost:9333 |
+| S3 public URL | `<s3_ngrok_url>` → localhost:8000 |
+
+If these change, run the `refresh-endpoints` workflow.
+
+## OSIS super-admin creds (for `ose osis admin set`)
+
+Access key: `<access_key>`
+(Secret in `dev/vcd-ose-lab/configs/lab.yaml`, never write the secret here.)
+```

--- a/.claude/skills/vcd-ose-lab/references/troubleshooting.md
+++ b/.claude/skills/vcd-ose-lab/references/troubleshooting.md
@@ -1,0 +1,98 @@
+# Troubleshooting — known gotchas
+
+Match the symptom to an entry below before improvising. Numbers correspond to the `#N` doc-gap markers in `references/install-sequence.md`.
+
+---
+
+**Symptom:** `dnf module enable postgresql:13` says "no such module".
+**Cause (#1):** Rocky 9 only ships `postgresql:15` and `:16` (PG 13 EOL'd Nov 2025).
+**Fix:** Use `postgresql:15`. VCD 10.5 is documented to work with PG 13–15.
+
+---
+
+**Symptom:** OSE RPM in the doc is `2.2.2-22098306.el7.x86_64.rpm`; you have a newer one like `3.0.0-23443325.el8.x86_64.rpm`.
+**Cause (#2):** The build moved on.
+**Fix:** Use whichever RPM is in your Drive. The CLI surface has minor changes (extra EULA-persist file, extra cert-trust prompt in `ose director set`) — captured throughout this doc.
+
+---
+
+**Symptom:** SQL sent to the VM via `tmux send-keys` fails with mangled quotes or truncated statements.
+**Cause (#5):** `tmux send-keys` mangles single quotes and multi-line input when SQL is typed inline into the pane.
+**Fix:** Put the SQL in a script using a quoted heredoc (`psql <<'SQL'`), SCP it to the VM, and run the script — exactly what `scripts/vm/postgres-setup.sh` does.
+
+---
+
+**Symptom:** Doc says `service vmware-vcd start`; it returns `Unit vmware-vcd.service not found.`
+**Cause (#6):** The VCD installer skips creating the systemd unit on Rocky 9 because it tries to call `/sbin/chkconfig` which doesn't exist. The installer ALSO tries to symlink `/etc/init.d/` which doesn't exist.
+**Fix:** Run `scripts/vm/install-vmware-vcd-systemd-unit.sh`. Also ensure `initscripts` is installed beforehand so `/etc/init.d/functions` exists (the VCD init script sources it).
+
+---
+
+**Symptom:** `vmware-vcd.service` fails to start with `ERROR: Unable to source system init functions, cannot proceed`.
+**Cause (#6, second half):** `initscripts` package missing → `/etc/init.d/functions` missing.
+**Fix:** `dnf install -y initscripts` then `systemctl start vmware-vcd`.
+
+---
+
+**Symptom:** VCD `configure` prints `/sbin/chkconfig: No such file or directory`.
+**Cause (#7):** Rocky 9 has no `chkconfig`; the installer's legacy service-registration step fails non-fatally.
+**Fix:** Ignore it — `configure` still completes (`Database configuration complete.`). The systemd unit is installed separately by `scripts/vm/install-vmware-vcd-systemd-unit.sh`.
+
+---
+
+**Symptom:** `https://<vm-ip>/provider` returns "Failed to Start: An error occurred during the initialization. Accessing the application through an unsupported public URL or poor connectivity might cause this error."
+**Cause (#9):** Two things in series. (a) The `sites` table has empty `rest_api_endpoint` / `base_ui_endpoint` / `multisite_url` — `system-setup` doesn't populate them. (b) Even after populating, accessing via the raw IP fails — the H5 UI only initializes cleanly via the FQDN that matches the cert CN.
+**Fix:**
+1. Run `scripts/vm/fix-vcd-public-urls.sh` (populates the table to the FQDN URL, restarts vmware-vcd).
+2. On the dev machine: `echo "<ip> <FQDN>" | sudo tee -a /etc/hosts`, system-trust the VCD cert (`security add-trusted-cert` on Mac, `update-ca-trust` / `update-ca-certificates` on Linux — `ca_trust_commands` in `scripts/local/lib/platform.sh` emits the right one), browse `https://<FQDN>/provider`.
+
+---
+
+**Symptom:** Building the OSE PKCS#12 hangs at `Enter pass phrase for cert.key:`.
+**Cause (#10):** The Confluence doc's `openssl pkcs12 -export` command omits `-passin`, so openssl prompts for the VCD key passphrase — and in a piped/scripted context the prompt just hangs.
+**Fix:** Use `scripts/vm/build-pkcs12-from-vcd-cert.sh` with `CERT_PASSPHRASE` set in the env (it passes `-passin env:CERT_PASSPHRASE`).
+
+---
+
+**Symptom:** `ose director set` fails with `Fail to set Cloud Director connection as EOF`, even with the password piped via `printf`.
+**Cause (#11):** OSE 3.0 prompts to **trust the self-signed VCD cert** with `y/N` *after* asking for the password. If you pipe only the password, the trust-cert prompt hits EOF and the connection setup fails.
+**Fix:** Run `ose director set` interactively. Send via two separate `tmux send-keys`: first the password, then `y`. Or extend the pipe: `printf "<password>\ny\n" | ose director set ...` if you're sure the order is right (it usually is).
+
+---
+
+**Symptom:** "Object Storage Extension service endpoint is found not accessible from your web browser" when clicking More → Object Storage in VCD.
+**Cause (#13):** OSE endpoint URL is set to the IP, but the user's dev machine trusts the cert by FQDN (or vice-versa). The cert SAN does include both, but OS-level CA trust + browser strict SAN matching only line up reliably with FQDN.
+**Fix:**
+1. Re-issue OSE PKCS12 with `-name <FQDN>` (use `scripts/vm/build-pkcs12-from-vcd-cert.sh`).
+2. `ose endpoint set --region=us-east-1 --url=https://<FQDN>:8443`.
+3. `ose service restart`.
+
+---
+
+**Symptom:** Object Storage panel loads partially, browser console shows CORS errors on `xhr` calls to OSE (e.g., `current-user`).
+**Cause (#14):** OSE allows CORS only for the URL configured as the Cloud Director. If VCD is accessed at the FQDN but `ose director set` was last called with the IP, the browser's `Origin: https://<FQDN>` header doesn't match OSE's allowlisted origin.
+**Fix:** Re-run `ose director set --url https://<FQDN> --user admin@system` (interactive — provide password, then `y` if it re-prompts cert trust; usually it won't, since OSE remembers). `ose service restart`.
+
+---
+
+**Symptom:** `Create S3 Credential error. NullPointerException: Cannot invoke "java.util.List.stream()" because the return value of "com.scality.osis.security.crypto.CryptoEnv.getKeys()" is null` in the OSIS log.
+**Cause (#N/A — local-dev specific):** OSIS reads `crypto.yml` from `file:/conf/crypto.yml` (hardcoded in `CryptoEnv.java`). Without the file present, every S3-credential operation throws this NPE.
+**Fix:** `sudo mkdir -p /conf && sudo cp /tmp/osis-local/crypto.yml /conf/crypto.yml && sudo chmod 644 /conf/crypto.yml`, then restart OSIS in its tmux.
+
+---
+
+**Symptom:** `Could not parse the specified URI. Check your restEndpoints configuration.` from S3 when OSE talks to it.
+**Cause:** The S3 ngrok hostname isn't in cloudserver's `restEndpoints` map. Cloudserver routes by Host header and rejects unknown hostnames.
+**Fix:** Add the S3 ngrok hostname to `$CLOUDSERVER_REPO/config.json` under `restEndpoints`, value `"us-east-1"`. Restart cloudserver in its tmux.
+
+---
+
+**Symptom:** OSIS log says `Cannot invoke "...RedisProperties$Sentinel.getMaster()" because the return value of "...getSentinel()" is null`.
+**Cause:** OSIS's `SpringRedisConfig` hardcodes Redis Sentinel mode. Plain `spring.redis.host` doesn't work.
+**Fix:** Start three Redis sentinels (`scripts/local/setup-redis-sentinels.sh`) and use `spring.redis.sentinel.master=mymaster` + `spring.redis.sentinel.nodes=localhost:26379,localhost:26380,localhost:26381` in `application.properties`.
+
+---
+
+**Symptom:** tmux pane has stale `^[[18;162R^[[18;162R` polluting subsequent commands.
+**Cause (#12):** `ose` emits ANSI cursor-position queries; the terminal replies with bytes that leak into stdin.
+**Fix:** Send `reset` to the tmux pane. The skill should do this after any sequence of `ose` commands if it intends to send-keys more commands after.

--- a/.claude/skills/vcd-ose-lab/workflows/refresh-endpoints.md
+++ b/.claude/skills/vcd-ose-lab/workflows/refresh-endpoints.md
@@ -1,0 +1,70 @@
+<required_reading>
+- `references/local-services.md` — to confirm local OSIS + S3 are alive at the new ngrok URLs.
+- `references/troubleshooting.md` — only if `ose config validate` fails.
+</required_reading>
+
+<when>
+ngrok restarted and the OSIS / S3 public URLs changed. The lab's VCD and OSE are unchanged, but OSE's OSIS-adapter config now points at stale tunnels.
+</when>
+
+<process>
+## Step 1 — Capture the new URLs
+
+```bash
+curl -s http://127.0.0.1:4040/api/tunnels | python3 -c \
+  'import sys,json; d=json.load(sys.stdin); [print(t["name"], t["public_url"]) for t in d["tunnels"]]'
+```
+
+Or ask the user, if they prefer.
+
+## Step 2 — Add the S3 ngrok hostname to cloudserver's restEndpoints
+
+Open `$CLOUDSERVER_REPO/config.json` (your local cloudserver checkout), find `restEndpoints`, add the new S3 ngrok hostname mapped to `us-east-1`. Restart cloudserver in its tmux:
+
+```bash
+tmux send-keys -t cloudserver C-c
+sleep 2
+tmux send-keys -t cloudserver 'S3VAULT=scality REMOTE_MANAGEMENT_DISABLE=1 yarn start' Enter
+```
+
+(If the S3 hostname is missing, cloudserver returns `Could not parse the specified URI. Check your restEndpoints configuration.` This is doc gap #N/A — local-dev specific, captured here.)
+
+## Step 3 — Update `configs/lab.yaml`
+
+Edit `dev/vcd-ose-lab/configs/lab.yaml` `endpoints.osis_url` and `endpoints.s3_url` to the new values. Update `_capture/session-state.local.md` too.
+
+## Step 4 — Re-wire OSE on the VM
+
+Read `instance private_ip` from `_capture/session-state.local.md` (or `terraform -chdir=terraform output -json`).
+
+SCP and run `scripts/vm/wire-osis.sh`. Run it over plain SSH rather than `tmux send-keys` (the tmux scroll buffer and `pipe-pane` log would capture the secret), and feed the secret over stdin so it never appears in the remote process listing — only the non-secret values go on the command line:
+
+```bash
+scp -i <key> dev/vcd-ose-lab/scripts/vm/wire-osis.sh rocky@<ip>:/tmp/
+ssh -i <key> rocky@<ip> 'IFS= read -r OSIS_SECRET_KEY; export OSIS_SECRET_KEY OSIS_URL="<osis_url>" S3_URL="<s3_url>" OSIS_ACCESS_KEY="<access_key>"; sudo -E bash /tmp/wire-osis.sh' <<< '<secret_key>'
+```
+
+(`wire-osis.sh` reads the secret from the env and feeds it to the `ose` prompt via stdin itself.)
+
+The script sends, in order:
+1. `ose osis admin set --name scality --url $OSIS_URL --user $OSIS_ACCESS_KEY` (interactive: provides secret + `y` for complexity warning)
+2. `ose osis s3 set --name scality --url $S3_URL`
+3. `ose platforms enable osis --name scality`
+4. `ose service restart`
+
+## Step 5 — Validate
+
+```bash
+ssh -i <key> rocky@<ip> 'tmux send-keys -t lab "ose config validate" Enter'
+sleep 4
+ssh -i <key> rocky@<ip> 'tmux capture-pane -t lab -p -S -60' | tail -30
+```
+
+All seven rows should be `Valid`. If any are not, jump to `references/troubleshooting.md`.
+</process>
+
+<success_criteria>
+- `ose config validate` all rows `Valid`.
+- `_capture/session-state.local.md` updated with new URLs.
+- VCD UI's Object Storage panel still loads, S3 credential operations still succeed.
+</success_criteria>

--- a/.claude/skills/vcd-ose-lab/workflows/spin-up.md
+++ b/.claude/skills/vcd-ose-lab/workflows/spin-up.md
@@ -1,0 +1,255 @@
+<required_reading>
+- `references/local-services.md` — local Vault/Cloudserver/OSIS must be running on the dev machine before any of this works.
+- `references/install-sequence.md` — phase-by-phase commands to run on the VM.
+- `references/troubleshooting.md` — known gotchas; consult on any failure.
+- `references/session-state-template.md` — write a fresh copy at the end.
+</required_reading>
+
+<prereqs>
+Before touching AWS:
+
+1. **Local services live.** Confirm `tmux ls` shows `vault`, `cloudserver`, `osis`, `ngrok`. If any are missing, walk the user through `references/local-services.md` first.
+
+2. **ngrok URLs in `lab.yaml`.** Read `dev/vcd-ose-lab/configs/lab.yaml`. The `endpoints.osis_url` and `endpoints.s3_url` must point to live ngrok hostnames, and **the S3 ngrok hostname must be in `cloudserver/config.json` under `restEndpoints`** (otherwise S3 returns `Could not parse the specified URI`). If the user hasn't restarted ngrok recently and the URLs in `lab.yaml` look stale, ask them.
+
+3. **Preflight green.** Run `cd dev/vcd-ose-lab && mage preflight`. Every row must be `[OK]`. Surface any `[FAIL]` to the user with the action line verbatim and stop.
+
+4. **Confirm scope and cost.** Before `terraform apply`, tell the user: "About to create a c5.4xlarge in eu-north-1 (~$0.85/hr). Proceed?" Wait for explicit yes.
+</prereqs>
+
+<process>
+## Phase 1 — AWS provisioning
+
+```bash
+cd dev/vcd-ose-lab
+mage tfvars                                   # renders configs/lab.yaml → terraform/terraform.tfvars
+terraform -chdir=terraform init -input=false  # idempotent
+terraform -chdir=terraform plan -out=tfplan   # show user before applying
+# After user confirms:
+terraform -chdir=terraform apply tfplan
+```
+
+Read outputs:
+```bash
+terraform -chdir=terraform output -json
+```
+
+Capture `instance_id`, `private_ip`, `ami_id` into `_capture/aws-notes.md` (a local-only, gitignored scratch file — create it if absent) and the running session-state.
+
+Wait for SSH to be reachable. First boot is ~55 seconds. Loop:
+
+```bash
+for i in {1..20}; do
+  ssh -q -o ConnectTimeout=5 -i <key> rocky@<private_ip> 'echo READY' && break
+  sleep 5
+done
+```
+
+## Phase 2 — Open the shared remote tmux session
+
+This is how the user attaches and watches. **All later commands go through this tmux**, not raw SSH `cmd` invocations.
+
+```bash
+ssh -q -i <key> rocky@<ip> 'sudo dnf install -y tmux'
+ssh -q -i <key> rocky@<ip> 'tmux new-session -d -s lab "bash"'
+ssh -q -i <key> rocky@<ip> 'tmux pipe-pane -t lab "cat >> /tmp/lab.log"'
+```
+
+Tell the user: "Attach with `ssh -i <key> -t rocky@<ip> 'tmux attach -t lab'` to watch."
+
+For each remote command, send it via:
+```bash
+ssh -q -i <key> rocky@<ip> "tmux send-keys -t lab '<command>; echo __DONE_<id>_\$?' Enter"
+```
+then poll `tmux capture-pane -t lab -p -S -500` for `__DONE_<id>_` and parse the exit code.
+
+## Phase 3 — Host bootstrap + PostgreSQL
+
+Become root and install packages. **Note the Rocky-9 specific bits**:
+- `dnf module enable postgresql:15` (not `:13` — doc gap #1).
+- Must include `initscripts` so `/etc/init.d/functions` exists; without it, vmware-vcd refuses to start later (doc gap #6).
+
+In tmux:
+```
+sudo -i
+sed -i 's/^.*ssh-rsa/ssh-rsa/' ~/.ssh/authorized_keys
+dnf update -y
+dnf module enable postgresql:15 -y
+dnf install -y vim nc bind bind-utils net-tools postgresql-server jq initscripts
+```
+
+Then run the postgres setup script. SCP it from the local repo and execute:
+```bash
+scp -i <key> dev/vcd-ose-lab/scripts/vm/postgres-setup.sh rocky@<ip>:/tmp/
+ssh ... 'tmux send-keys -t lab "PG_PASSWORD='"'"'<postgres_password from lab.yaml>'"'"' bash /tmp/postgres-setup.sh" Enter'
+```
+
+`postgres-setup.sh` requires `PG_PASSWORD` in the env (it refuses to run without it) and does: initdb, write a local-only `pg_hba.conf` (peer + scram-sha-256 loopback), sed `postgresql.conf`, `systemctl start postgresql && enable`, create `vcdadmin`/`oseadmin` + `vcddb`/`osedb`, set `osedb` collation to `C`. PostgreSQL only listens on localhost — VCD and OSE run on the same host, so nothing else needs to reach it.
+
+## Phase 4 — VCD install (the .bin)
+
+SCP the binaries (don't forget `sudo mv` to `/root/` since `scp` lands them in `/home/rocky/`):
+```bash
+scp -i <key> dev/vcd-ose-lab/binaries/vmware-vcloud-director-distribution-*.bin rocky@<ip>:/home/rocky/
+ssh ... 'sudo mv /home/rocky/vmware-vcloud-director-*.bin /root/'
+```
+
+In tmux, run the installer with **stdin piped** to skip both interactive prompts:
+```
+chmod u+x /root/vmware-vcloud-director-distribution-*.bin
+printf 'y\nn\n' | /root/vmware-vcloud-director-distribution-*.bin
+```
+
+`y` answers "You are not running a supported Linux distribution. Proceed anyway?". `n` answers "Would you like to run the configuration script now?" (we run it ourselves in the next phase).
+
+You will see `/bin/ln: failed to create symbolic link '/etc/init.d/'`. That's expected — doc gap #6. The systemd unit is missing too; we'll install it manually.
+
+## Phase 5 — VCD configure
+
+```
+export HOST_IP=$(hostname -I | awk '{print $1}')
+export FQDN=$(hostname -f)
+cd /opt/vmware/vcloud-director/
+/opt/vmware/vcloud-director/bin/cell-management-tool generate-certs \
+  --cert cert.pem --key cert.key --key-password '<vcd_cert_passphrase from lab.yaml>'
+```
+
+The configure command takes a long flag list — read it from `references/install-sequence.md` (Phase 5). Use values from `lab.yaml`: `postgres_password`, `vcd_cert_passphrase`, `--primary-ip $HOST_IP`.
+
+After `configure` finishes (it prints `Database configuration complete.` and a non-fatal `chkconfig: No such file or directory`), install the systemd unit and start VCD:
+
+```bash
+scp -i <key> dev/vcd-ose-lab/scripts/vm/install-vmware-vcd-systemd-unit.sh rocky@<ip>:/tmp/
+ssh ... 'tmux send-keys -t lab "bash /tmp/install-vmware-vcd-systemd-unit.sh && systemctl start vmware-vcd" Enter'
+```
+
+Wait until `cell.log` shows `Cell startup completed` (takes ~110 seconds). Poll:
+```bash
+ssh ... 'sudo grep -c "Cell startup completed" /opt/vmware/vcloud-director/logs/cell.log'
+```
+
+Then run `system-setup` with **password piped twice + Y for confirmation**. Run it over plain SSH, not the tmux pane — the pane is mirrored to `/tmp/lab.log` and would capture the password:
+```bash
+printf '%s\n%s\nY\n' '<vcd_admin_password>' '<vcd_admin_password>' | \
+  ssh -i <key> rocky@<ip> 'sudo /opt/vmware/vcloud-director/bin/cell-management-tool system-setup \
+    --user admin \
+    --full-name "VCD System Administrator" \
+    --email vcd-admin@scality.lab \
+    --system-name VCD \
+    --installation-id 2'
+```
+
+Finally, **populate the `sites` table to make the H5 UI work** (doc gap #9). SCP + run:
+```bash
+scp -i <key> dev/vcd-ose-lab/scripts/vm/fix-vcd-public-urls.sh rocky@<ip>:/tmp/
+ssh ... 'tmux send-keys -t lab "bash /tmp/fix-vcd-public-urls.sh" Enter'
+```
+
+That script does `UPDATE sites SET rest_api_endpoint='https://<FQDN>', base_ui_endpoint='https://<FQDN>', multisite_url='https://<FQDN>', name='VCD' WHERE is_local_site=true` and restarts vmware-vcd.
+
+Wait again for `Cell startup completed`.
+
+## Phase 6 — OSE install + EULA
+
+```bash
+scp -i <key> dev/vcd-ose-lab/binaries/vmware-ose-*.rpm rocky@<ip>:/home/rocky/
+ssh ... 'sudo mv /home/rocky/vmware-ose-*.rpm /root/'
+```
+
+In tmux:
+```
+cd /root && dnf install -y ./vmware-ose-*.rpm
+echo accept | ose -h
+```
+
+The `echo accept` persists EULA acceptance to `/opt/vmware/voss/agreement`. Subsequent ose commands won't re-prompt (doc gap #11).
+
+## Phase 7 — OSE configure
+
+SCP the PKCS12-build script:
+```bash
+scp -i <key> dev/vcd-ose-lab/scripts/vm/build-pkcs12-from-vcd-cert.sh rocky@<ip>:/tmp/
+```
+
+This script wraps the openssl + `ose cert import` pair, with the two fixes from doc gaps #10 and #13: `-passin env:CERT_PASSPHRASE` (so it doesn't prompt for the input key passphrase, and the passphrase never hits argv) and `-name <FQDN>` (so the keystore alias matches the cert CN — critical for browser trust later). `CERT_PASSPHRASE` is required in the env.
+
+```
+CERT_PASSPHRASE='<vcd_cert_passphrase from lab.yaml>' bash /tmp/build-pkcs12-from-vcd-cert.sh
+ose db set --url jdbc:postgresql://localhost:5432/osedb --user oseadmin --secret '<postgres_password from lab.yaml>'
+```
+
+Then `ose director set` — **interactive in tmux**, not piped, because OSE prompts to trust the VCD cert with `y/N` and that prompt eats piped stdin:
+
+```
+ose director set --url https://$FQDN --user admin@system
+# at "Secret :", type the VCD admin password
+# at "Do you trust this certificate for the SSL connection?", type y
+```
+
+The agent should send these via separate `tmux send-keys` after polling capture-pane for each prompt. If you pipe both at once via `printf`, the trust-cert prompt fails with "Fail to set Cloud Director connection as EOF" (doc gap #11).
+
+```
+ose endpoint set --region=us-east-1 --url=https://$FQDN:8443
+ose ui install
+```
+
+## Phase 8 — OSIS wiring
+
+Read `endpoints.osis_url`, `endpoints.s3_url`, `secrets.osis_super_admin_access_key`, `secrets.osis_super_admin_secret_key` from `lab.yaml`.
+
+First, in tmux (no secrets involved):
+```
+ose args set -k server.port -v 8443
+systemctl start voss-keeper
+```
+
+Then SCP and run `scripts/vm/wire-osis.sh` over plain SSH — never type the secret into the tmux pane (it's mirrored to `/tmp/lab.log`). Same pattern as refresh-endpoints: the secret rides stdin, only non-secret values go on the command line:
+```bash
+scp -i <key> dev/vcd-ose-lab/scripts/vm/wire-osis.sh rocky@<ip>:/tmp/
+ssh -i <key> rocky@<ip> 'IFS= read -r OSIS_SECRET_KEY; export OSIS_SECRET_KEY OSIS_URL="<osis_url>" S3_URL="<s3_url>" OSIS_ACCESS_KEY="<access_key>"; sudo -E bash /tmp/wire-osis.sh' <<< '<secret_key>'
+```
+
+The script runs `ose osis admin set` (secret fed via stdin, `y` for the complexity warning), `ose osis s3 set`, `ose platforms enable osis`, and `ose service restart`.
+
+Then `ose config validate`. Expect **all seven rows Valid**:
+```
+OSE Endpoint, Database, Certificate, Cloud Director, Platform-scality, Admin, S3
+```
+
+If any row is not Valid, jump to `references/troubleshooting.md` matching the row name.
+
+## Phase 9 — Make the H5 UI usable from the dev machine
+
+Print these commands for the user to run on their own machine (the skill cannot do these — they need sudo on the user's box). Detect the OS first and only print the matching `security` / `update-ca-trust` / `update-ca-certificates` form. Use the `ca_trust_commands` helper:
+
+```bash
+. dev/vcd-ose-lab/scripts/local/lib/platform.sh
+echo "<private_ip>  <FQDN>" | sudo tee -a /etc/hosts
+ssh -i <key> rocky@<private_ip> 'sudo cp /opt/vmware/vcloud-director/cert.pem /tmp/vcd-cert.pem && sudo chmod 644 /tmp/vcd-cert.pem'
+scp -i <key> rocky@<private_ip>:/tmp/vcd-cert.pem ~/Downloads/vcd-lab.pem
+ca_trust_commands ~/Downloads/vcd-lab.pem
+```
+
+The `ca_trust_commands` line prints the correct commands for the detected OS:
+
+- **Mac:** `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/Downloads/vcd-lab.pem`
+- **Linux (Debian/Ubuntu):** `sudo cp ~/Downloads/vcd-lab.pem /usr/local/share/ca-certificates/vcd-lab.crt && sudo update-ca-certificates`
+- **Linux (Fedora/Rocky/RHEL):** `sudo cp ~/Downloads/vcd-lab.pem /etc/pki/ca-trust/source/anchors/vcd-lab.pem && sudo update-ca-trust`
+
+After running them they can browse `https://<FQDN>/provider`, log in with `admin / <vcd_admin_password>`, and More → Object Storage should load without CORS errors or self-signed warnings.
+
+> Firefox on Linux uses its own NSS trust store, not the system one. If the user opens VCD in Firefox, also import the PEM in Settings → Privacy & Security → View Certificates → Import. Chrome/Chromium on Linux uses the system NSS DB so the commands above are enough.
+
+## Phase 10 — Capture state
+
+Write `_capture/session-state.local.md` from `references/session-state-template.md`, filled in with: instance ID, private IP, FQDN, current ngrok URLs, super-admin access key (not secret), key file path, date. This file is gitignored.
+
+Append to `_capture/aws-notes.md` (local-only, gitignored) a brief line with the date and AMI/region used.
+</process>
+
+<success_criteria>
+- `ose config validate` on the VM shows all seven rows `Valid`.
+- The user confirms `https://<FQDN>/provider` loads, More → Object Storage opens, and creating an S3 credential succeeds (no NPE).
+- `_capture/session-state.local.md` is up-to-date.
+- Total wall-clock: 25–35 minutes (binaries SCP ~5-10, VCD configure ~3-5, VCD boot ~2-3, OSE configure ~3-5, the rest is human-paced).
+</success_criteria>

--- a/.claude/skills/vcd-ose-lab/workflows/ssh-to-lab.md
+++ b/.claude/skills/vcd-ose-lab/workflows/ssh-to-lab.md
@@ -1,0 +1,25 @@
+<process>
+Read `instance private_ip` and `key_path` from `_capture/session-state.local.md`.
+
+Print the user-facing command (do not execute — interactive shells can't be driven cleanly by the agent):
+
+```bash
+ssh -i <key_path> -t rocky@<private_ip> 'tmux attach -t lab'
+```
+
+If they want a fresh shell instead of the lab session:
+
+```bash
+ssh -i <key_path> rocky@<private_ip>
+```
+
+If they want a shared, recoverable session for new long-running commands and there's no `lab` tmux yet (or it was killed):
+
+```bash
+ssh -i <key_path> -t rocky@<private_ip> 'tmux new-session -A -s lab'
+```
+</process>
+
+<success_criteria>
+User has a copy-pasteable SSH command they can run. No tool calls modify the lab state.
+</success_criteria>

--- a/.claude/skills/vcd-ose-lab/workflows/status.md
+++ b/.claude/skills/vcd-ose-lab/workflows/status.md
@@ -1,0 +1,56 @@
+<process>
+Read `instance private_ip` from `_capture/session-state.local.md` (or `terraform -chdir=terraform output -json`). If neither yields a value, tell the user "no lab is currently provisioned" and stop.
+
+## On the VM
+
+```bash
+ssh -q -i <key> rocky@<ip> 'tmux send-keys -t lab "ose config validate && systemctl is-active postgresql vmware-vcd voss-keeper" Enter'
+sleep 4
+ssh -q -i <key> rocky@<ip> 'tmux capture-pane -t lab -p -S -80' | tail -30
+```
+
+Expected: seven `Valid` rows from `ose config validate`, three `active` lines from `systemctl is-active`.
+
+Also peek at the VCD cell health:
+```bash
+ssh -q -i <key> rocky@<ip> 'sudo tail -5 /opt/vmware/vcloud-director/logs/cell.log'
+```
+
+The last cell startup line should say `Cell startup completed in ...`.
+
+## On the dev machine
+
+Verify local services + ngrok still up:
+
+```bash
+for s in vault cloudserver osis ngrok; do
+  tmux has-session -t $s 2>/dev/null && echo "$s: tmux present" || echo "$s: MISSING"
+done
+
+curl -sf http://localhost:9333/_/healthcheck | python3 -m json.tool
+
+curl -s http://127.0.0.1:4040/api/tunnels | python3 -c \
+  'import sys,json; d=json.load(sys.stdin); [print(t["name"], t["public_url"]) for t in d["tunnels"]]'
+```
+
+Verify the ngrok URLs in the live API match what's in `configs/lab.yaml`. If they differ, the user needs to run the `refresh-endpoints` workflow.
+
+## Report
+
+Render a compact table:
+
+```
+Lab: <instance-id> (<private-ip> / FQDN)
+ose config validate : all VALID  | (or list failing rows)
+postgresql          : active
+vmware-vcd          : active
+voss-keeper         : active
+Local osis health   : UP (vault, redis, s3, ping all UP)
+Local services      : vault ✓  cloudserver ✓  osis ✓  ngrok ✓
+ngrok URLs match    : yes / NO — run refresh-endpoints
+```
+</process>
+
+<success_criteria>
+User has a clear picture of which component, if any, is degraded, and the next workflow to run if so.
+</success_criteria>

--- a/.claude/skills/vcd-ose-lab/workflows/tear-down.md
+++ b/.claude/skills/vcd-ose-lab/workflows/tear-down.md
@@ -1,0 +1,59 @@
+<process>
+## Step 1 — Confirm with the user
+
+The lab is about to be **destroyed**. Quote the current `_capture/session-state.local.md` instance ID and cost-to-date if obvious, then ask: "Destroy AWS resources for VCD lab `i-XXXXX`?"
+
+Wait for explicit yes.
+
+## Step 2 — terraform destroy
+
+```bash
+cd dev/vcd-ose-lab
+terraform -chdir=terraform destroy -auto-approve
+```
+
+Expected output ends with `Destroy complete! Resources: 1 destroyed.`
+
+## Step 3 — Verify
+
+```bash
+terraform -chdir=terraform state list   # should be empty
+```
+
+Optionally, double-check via AWS:
+```bash
+aws ec2 describe-instances --profile sso --region eu-north-1 \
+  --filters Name=tag:Project,Values=OSIS-VCD-Lab \
+  --query 'Reservations[*].Instances[?State.Name!=`terminated`].[InstanceId,State.Name]' \
+  --output table
+```
+
+Should show no non-terminated instances.
+
+## Step 4 — Local cleanup (optional)
+
+Ask the user if they want to also stop their local services:
+
+```bash
+tmux kill-session -t osis
+tmux kill-session -t cloudserver
+tmux kill-session -t vault
+tmux kill-session -t ngrok
+# Sentinels (daemonized, not in tmux):
+pkill -f 'redis-sentinel /tmp/osis-local/sentinels'
+```
+
+And whether to remove `_capture/session-state.local.md` (gitignored so it doesn't matter for git, but stale info can mislead next time).
+
+Everything under `_capture/` (except its README) is local-only and gitignored — the durable knowledge lives in `references/install-sequence.md` and `references/troubleshooting.md`. Leave any other local capture files alone unless the user asks.
+
+## Step 5 — Report
+
+Print: "Lab `i-XXXXX` destroyed. Local services [stopped|left running]. Ready for next `spin-up`."
+</process>
+
+<success_criteria>
+- `terraform state list` empty.
+- AWS console / CLI confirms no non-terminated instances tagged `Project=OSIS-VCD-Lab`.
+- User confirms they're done; no surprise bills.
+</success_criteria>

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.DS_Store
 
 build/
 reports/

--- a/dev/vcd-ose-lab/.gitignore
+++ b/dev/vcd-ose-lab/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+configs/lab.yaml
+terraform/terraform.tfvars
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
+terraform/tfplan
+binaries/*.bin
+binaries/*.rpm
+_capture/*
+!_capture/README.md
+!_capture/.gitkeep

--- a/dev/vcd-ose-lab/_capture/README.md
+++ b/dev/vcd-ose-lab/_capture/README.md
@@ -1,0 +1,11 @@
+# Capture
+
+Local-only scratch space for ride-along artifacts from manual lab runs. Everything in this directory except this README is gitignored — nothing here gets committed, so raw notes with instance IDs, IPs, and timings are fine to keep.
+
+Typical contents:
+
+- `session-state.local.md` — live lab state (instance ID, IPs, ngrok URLs); written by the `spin-up` workflow, updated by `refresh-endpoints`.
+- `SHELL_HISTORY.md` — every command run during a manual ride-along, in order, with outputs and timings.
+- `aws-notes.md` — AMI IDs, region quirks, instance behavior.
+
+Durable knowledge does not live here. When a run surfaces a new gotcha or doc gap, fold it into `.claude/skills/vcd-ose-lab/references/install-sequence.md` or `references/troubleshooting.md` — those are the committed ground truth.

--- a/dev/vcd-ose-lab/binaries/.gitignore
+++ b/dev/vcd-ose-lab/binaries/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/dev/vcd-ose-lab/binaries/README.md
+++ b/dev/vcd-ose-lab/binaries/README.md
@@ -1,0 +1,10 @@
+# Binaries
+
+VMware binaries are not redistributable. Download them from Scality's internal Drive and place them here:
+
+- `vmware-vcloud-director-distribution-<version>.bin`
+- `vmware-ose-<version>.el7.x86_64.rpm`
+
+Drive links are tracked in the Scality-internal Confluence page (id `2138571097`).
+
+`mage preflight` verifies these files exist (and optionally checks MD5 from `configs/lab.yaml`) before the `spin-up` workflow uses them.

--- a/dev/vcd-ose-lab/configs/lab.example.yaml
+++ b/dev/vcd-ose-lab/configs/lab.example.yaml
@@ -1,0 +1,43 @@
+# Copy to lab.yaml and fill in. lab.yaml is gitignored.
+
+aws:
+  profile: sso                  # AWS named profile (configured via `aws configure sso`)
+  region: eu-north-1            # one of: eu-north-1, us-west-2, ap-northeast-1
+  subnet_id: subnet-XXXXXXXX    # a *-private-* subnet in the Scality managed VPC
+  # Attach BOTH the allow-vpn-private-and-vms SG (always required for Scality
+  # VPN reach) AND a per-user SG carrying the lab's inbound rules
+  # (HTTP/80, HTTPS/443, SSH/22, PostgreSQL/5432, NFS/2049, 8080, 8443).
+  # Create the per-user SG once per account; see docs/README.md.
+  security_group_ids:
+    - sg-XXXXXXXX               # allow-vpn-private-and-vms
+    - sg-YYYYYYYY               # your per-user inbound-rules SG
+  key_name: my-key              # AWS key pair name
+  key_path: ~/.ssh/my-key.pem   # local path to the matching .pem
+  instance_type: c5.4xlarge
+  root_volume_gb: 400
+  root_volume_type: gp2
+  os: rocky-9                   # rocky-8 | rocky-9
+
+vmware:
+  vcd_bin_glob: vmware-vcloud-director-distribution-*.bin
+  vcd_bin_md5: ""               # optional MD5 check; leave empty to skip
+  ose_rpm_glob: vmware-ose-*.rpm
+  ose_rpm_md5: ""
+
+# Endpoints the lab's OSE will be wired against. When ngrok URLs change,
+# edit these and run the `refresh-endpoints` workflow.
+endpoints:
+  osis_url: https://example.ngrok.app
+  vault_url: https://example.ngrok.app
+  s3_url:   https://example.ngrok.app
+  platform_name: scality
+  region: us-east-1
+
+# Secrets. Fill in; do not commit lab.yaml. All five are required by
+# preflight — pick strong values, do not reuse weak doc defaults.
+secrets:
+  vcd_admin_password: ""              # VCD provider UI admin password
+  postgres_password: ""               # used by both vcdadmin and oseadmin DB users
+  osis_super_admin_access_key: ""     # from your local Vault dev DB
+  osis_super_admin_secret_key: ""
+  vcd_cert_passphrase: ""             # PKCS#12 passphrase for VCD cert + OSE keystore

--- a/dev/vcd-ose-lab/configs/lab.example.yaml
+++ b/dev/vcd-ose-lab/configs/lab.example.yaml
@@ -28,7 +28,6 @@ vmware:
 # edit these and run the `refresh-endpoints` workflow.
 endpoints:
   osis_url: https://example.ngrok.app
-  vault_url: https://example.ngrok.app
   s3_url:   https://example.ngrok.app
   platform_name: scality
   region: us-east-1

--- a/dev/vcd-ose-lab/docs/README.md
+++ b/dev/vcd-ose-lab/docs/README.md
@@ -1,0 +1,65 @@
+# VCD-OSE Lab
+
+Brings up a VMware Cloud Director + Object Storage Extension lab on a Rocky 9 EC2 VM and wires it to externally-running Scality OSIS/Vault/S3 endpoints. Intended for OSIS development and integration testing.
+
+Source doc (Scality-internal): Confluence page id `2138571097`, "Creating a VMware Cloud Director Object Storage Extension Lab on Rocky 8".
+
+## Prerequisites
+
+- A dev machine (Mac or Linux — Debian/Ubuntu or Fedora/Rocky/RHEL) with: `go` (1.21+), `mage`, `terraform`, `ssh`, `scp`, `tmux`, `redis`, JDK 17, `ngrok`, `jq`.
+  - **Mac:** `brew install go mage terraform tmux redis openjdk@17 ngrok jq`
+  - **Debian/Ubuntu:** `sudo apt install golang-go tmux redis-server openjdk-17-jdk jq`; install terraform via the HashiCorp apt repo and ngrok via https://ngrok.com/download `.deb`; install mage with `go install github.com/magefile/mage@latest`.
+  - **Fedora/Rocky/RHEL:** `sudo dnf install golang tmux redis java-17-openjdk-devel jq`; `sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && sudo dnf install terraform`; ngrok via https://ngrok.com/download `.rpm`; mage with `go install github.com/magefile/mage@latest`.
+- AWS access to one of: `eu-north-1`, `us-west-2`, `ap-northeast-1`. Configured via `aws sso login` (or static creds).
+- Scality VPN connection.
+- VMware binaries placed in `binaries/` (see `binaries/README.md`).
+- `configs/lab.yaml` populated from `configs/lab.example.yaml`.
+- OSIS/Vault/S3 running and reachable from EC2 (e.g., via ngrok), URLs set in `configs/lab.yaml`.
+
+## Usage
+
+Mage covers the two pieces that are usefully wrapped in Go (typed config + structured preflight checks). Everything else — provisioning, install, wiring, teardown — is driven by the `vcd-ose-lab` Claude Code skill at `.claude/skills/vcd-ose-lab/`. The skill is the orchestrator; it calls `terraform` and `ssh` directly via Bash following the workflows in `.claude/skills/vcd-ose-lab/workflows/`.
+
+```
+mage preflight    # verify prerequisites (with one actionable line per failure)
+mage tfvars       # render configs/lab.yaml into terraform/terraform.tfvars
+```
+
+A passing `mage preflight` looks like this:
+
+```
+[OK] config file
+[OK] config fields
+[OK] terraform on PATH
+[OK] aws on PATH
+[OK] ssh on PATH
+[OK] scp on PATH
+[OK] AWS credentials (profile sso)
+[OK] SSH key
+[OK] VCD installer (.bin)  (vmware-vcloud-director-distribution-10.5.1-23401219.bin)
+[OK] OSE package (.rpm)  (vmware-ose-3.0.0-23443325.el8.x86_64.rpm)
+```
+
+Any `[FAIL]` row prints an actionable next step (install a tool, fill a config field, `aws sso login`, etc). Fix each and re-run.
+
+## Agent usage
+
+Invoke the OSIS skill `vcd-ose-lab` (at `.claude/skills/vcd-ose-lab/SKILL.md`). Say one of: "spin up VCD lab", "tear down VCD lab", "refresh OSE endpoints", "VCD lab status", "ssh to VCD lab". The skill routes to the matching workflow and drives terraform/ssh from there. Preflight failures surface as human-actionable instructions.
+
+## After the lab is up
+
+Trust the VCD certificate on your dev machine so the provider UI loads without warnings:
+
+```bash
+scp -i <key> rocky@<eth0_ip>:/opt/vmware/vcloud-director/cert.pem ~/Downloads/vcd-lab.pem
+```
+
+Then **one** of (sourcing `scripts/local/lib/platform.sh` lets `ca_trust_commands` pick the right one for you):
+
+- **Mac:** `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/Downloads/vcd-lab.pem`
+- **Debian/Ubuntu:** `sudo cp ~/Downloads/vcd-lab.pem /usr/local/share/ca-certificates/vcd-lab.crt && sudo update-ca-certificates`
+- **Fedora/Rocky/RHEL:** `sudo cp ~/Downloads/vcd-lab.pem /etc/pki/ca-trust/source/anchors/vcd-lab.pem && sudo update-ca-trust`
+
+Add the FQDN ↔ private IP mapping to your `/etc/hosts` (same path on Mac and Linux). Then visit `https://<eth0-FQDN>/provider` (requires Scality VPN).
+
+Firefox on Linux uses its own NSS trust store — import the PEM under Settings → Privacy & Security → View Certificates → Import if you use Firefox. Chrome/Chromium read the system NSS DB and are fine after `update-ca-trust` / `update-ca-certificates`.

--- a/dev/vcd-ose-lab/go.mod
+++ b/dev/vcd-ose-lab/go.mod
@@ -1,0 +1,5 @@
+module github.com/scality/osis/dev/vcd-ose-lab
+
+go 1.21
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/dev/vcd-ose-lab/go.sum
+++ b/dev/vcd-ose-lab/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/dev/vcd-ose-lab/internal/awsx/awsx.go
+++ b/dev/vcd-ose-lab/internal/awsx/awsx.go
@@ -1,0 +1,67 @@
+package awsx
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/scality/osis/dev/vcd-ose-lab/internal/config"
+)
+
+// WriteTfvars generates terraform.tfvars from the lab config. The file
+// is gitignored. Called before every apply/destroy so changes to lab.yaml
+// flow through without manual sync.
+//
+// Terraform itself (init/plan/apply/destroy/output) is driven directly by
+// the vcd-ose-lab skill workflows, not from here — see SKILL.md ("There is
+// no mage up"). Mage's only jobs are preflight and rendering this file.
+func WriteTfvars(tfDir string, cfg *config.Config) error {
+	sgList := "["
+	for i, id := range cfg.AWS.SecurityGroupIDs {
+		if i > 0 {
+			sgList += ", "
+		}
+		sgList += fmt.Sprintf("%q", id)
+	}
+	sgList += "]"
+
+	rootVolumeType := cfg.AWS.RootVolumeType
+	if rootVolumeType == "" {
+		rootVolumeType = "gp2"
+	}
+	rootVolumeGB := cfg.AWS.RootVolumeGB
+	if rootVolumeGB == 0 {
+		rootVolumeGB = 400
+	}
+	instanceType := cfg.AWS.InstanceType
+	if instanceType == "" {
+		instanceType = "c5.4xlarge"
+	}
+	// aws.os selects the Rocky AMI generation; rocky-9 is the default.
+	amiPattern := "Rocky-9-EC2-Base-*"
+	if cfg.AWS.OS == "rocky-8" {
+		amiPattern = "Rocky-8-EC2-Base-*"
+	}
+
+	content := fmt.Sprintf(`aws_profile            = %q
+aws_region             = %q
+subnet_id              = %q
+security_group_ids     = %s
+key_name               = %q
+instance_type          = %q
+root_volume_gb         = %d
+root_volume_type       = %q
+rocky_ami_name_pattern = %q
+`,
+		cfg.AWS.Profile,
+		cfg.AWS.Region,
+		cfg.AWS.SubnetID,
+		sgList,
+		cfg.AWS.KeyName,
+		instanceType,
+		rootVolumeGB,
+		rootVolumeType,
+		amiPattern,
+	)
+	return os.WriteFile(filepath.Join(tfDir, "terraform.tfvars"), []byte(content), 0o600)
+}

--- a/dev/vcd-ose-lab/internal/config/config.go
+++ b/dev/vcd-ose-lab/internal/config/config.go
@@ -37,7 +37,6 @@ type VMwareConfig struct {
 
 type EndpointsConfig struct {
 	OSISURL      string `yaml:"osis_url"`
-	VaultURL     string `yaml:"vault_url"`
 	S3URL        string `yaml:"s3_url"`
 	PlatformName string `yaml:"platform_name"`
 	Region       string `yaml:"region"`
@@ -91,7 +90,6 @@ func (c *Config) MissingRequired() []string {
 	check("aws.key_name", c.AWS.KeyName)
 	check("aws.key_path", c.AWS.KeyPath)
 	check("endpoints.osis_url", c.Endpoints.OSISURL)
-	check("endpoints.vault_url", c.Endpoints.VaultURL)
 	check("endpoints.s3_url", c.Endpoints.S3URL)
 	check("secrets.vcd_admin_password", c.Secrets.VCDAdminPassword)
 	check("secrets.postgres_password", c.Secrets.PostgresPassword)

--- a/dev/vcd-ose-lab/internal/config/config.go
+++ b/dev/vcd-ose-lab/internal/config/config.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	AWS       AWSConfig       `yaml:"aws"`
+	VMware    VMwareConfig    `yaml:"vmware"`
+	Endpoints EndpointsConfig `yaml:"endpoints"`
+	Secrets   SecretsConfig   `yaml:"secrets"`
+}
+
+type AWSConfig struct {
+	Profile          string   `yaml:"profile"`
+	Region           string   `yaml:"region"`
+	SubnetID         string   `yaml:"subnet_id"`
+	SecurityGroupIDs []string `yaml:"security_group_ids"`
+	KeyName          string   `yaml:"key_name"`
+	KeyPath          string   `yaml:"key_path"`
+	InstanceType     string   `yaml:"instance_type"`
+	RootVolumeGB     int      `yaml:"root_volume_gb"`
+	RootVolumeType   string   `yaml:"root_volume_type"`
+	OS               string   `yaml:"os"`
+}
+
+type VMwareConfig struct {
+	VCDBinGlob string `yaml:"vcd_bin_glob"`
+	VCDBinMD5  string `yaml:"vcd_bin_md5"`
+	OSERPMGlob string `yaml:"ose_rpm_glob"`
+	OSERPMMD5  string `yaml:"ose_rpm_md5"`
+}
+
+type EndpointsConfig struct {
+	OSISURL      string `yaml:"osis_url"`
+	VaultURL     string `yaml:"vault_url"`
+	S3URL        string `yaml:"s3_url"`
+	PlatformName string `yaml:"platform_name"`
+	Region       string `yaml:"region"`
+}
+
+type SecretsConfig struct {
+	VCDAdminPassword        string `yaml:"vcd_admin_password"`
+	PostgresPassword        string `yaml:"postgres_password"`
+	OSISSuperAdminAccessKey string `yaml:"osis_super_admin_access_key"`
+	OSISSuperAdminSecretKey string `yaml:"osis_super_admin_secret_key"`
+	VCDCertPassphrase       string `yaml:"vcd_cert_passphrase"`
+}
+
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var c Config
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	c.AWS.KeyPath = expandHome(c.AWS.KeyPath)
+	return &c, nil
+}
+
+func expandHome(p string) string {
+	if len(p) > 1 && p[:2] == "~/" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
+// MissingRequired returns a list of human-readable field names that are required but empty.
+func (c *Config) MissingRequired() []string {
+	var missing []string
+	check := func(field, value string) {
+		if value == "" {
+			missing = append(missing, field)
+		}
+	}
+	check("aws.profile", c.AWS.Profile)
+	check("aws.region", c.AWS.Region)
+	check("aws.subnet_id", c.AWS.SubnetID)
+	if len(c.AWS.SecurityGroupIDs) == 0 {
+		missing = append(missing, "aws.security_group_ids")
+	}
+	check("aws.key_name", c.AWS.KeyName)
+	check("aws.key_path", c.AWS.KeyPath)
+	check("endpoints.osis_url", c.Endpoints.OSISURL)
+	check("endpoints.vault_url", c.Endpoints.VaultURL)
+	check("endpoints.s3_url", c.Endpoints.S3URL)
+	check("secrets.vcd_admin_password", c.Secrets.VCDAdminPassword)
+	check("secrets.postgres_password", c.Secrets.PostgresPassword)
+	check("secrets.osis_super_admin_access_key", c.Secrets.OSISSuperAdminAccessKey)
+	check("secrets.osis_super_admin_secret_key", c.Secrets.OSISSuperAdminSecretKey)
+	check("secrets.vcd_cert_passphrase", c.Secrets.VCDCertPassphrase)
+	return missing
+}

--- a/dev/vcd-ose-lab/internal/lab/lab.go
+++ b/dev/vcd-ose-lab/internal/lab/lab.go
@@ -1,0 +1,1 @@
+package lab

--- a/dev/vcd-ose-lab/internal/preflight/preflight.go
+++ b/dev/vcd-ose-lab/internal/preflight/preflight.go
@@ -1,0 +1,196 @@
+package preflight
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/scality/osis/dev/vcd-ose-lab/internal/config"
+)
+
+type Check struct {
+	Name   string
+	OK     bool
+	Detail string
+	Action string
+}
+
+// Run executes every prerequisite check and returns them in order.
+// repoRoot is the absolute path to dev/vcd-ose-lab.
+func Run(repoRoot string) []Check {
+	var checks []Check
+
+	cfgPath := filepath.Join(repoRoot, "configs", "lab.yaml")
+	if _, err := os.Stat(cfgPath); err != nil {
+		return []Check{{
+			Name:   "config file",
+			OK:     false,
+			Detail: "configs/lab.yaml not found",
+			Action: "Copy configs/lab.example.yaml to configs/lab.yaml and fill in the required fields.",
+		}}
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return []Check{{
+			Name:   "config file",
+			OK:     false,
+			Detail: err.Error(),
+			Action: "Fix the YAML syntax in configs/lab.yaml.",
+		}}
+	}
+	checks = append(checks, Check{Name: "config file", OK: true})
+
+	if missing := cfg.MissingRequired(); len(missing) > 0 {
+		checks = append(checks, Check{
+			Name:   "config fields",
+			OK:     false,
+			Detail: "missing: " + strings.Join(missing, ", "),
+			Action: "Populate the listed fields in configs/lab.yaml.",
+		})
+	} else {
+		checks = append(checks, Check{Name: "config fields", OK: true})
+	}
+
+	checks = append(checks, checkTool("terraform", installHint("terraform", "https://developer.hashicorp.com/terraform/install")))
+	checks = append(checks, checkTool("aws", installHint("awscli", "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")))
+	checks = append(checks, checkTool("ssh", "ssh is required (preinstalled on macOS/Linux)"))
+	checks = append(checks, checkTool("scp", "scp is required (preinstalled on macOS/Linux)"))
+
+	checks = append(checks, checkAWSCreds(cfg.AWS.Profile, cfg.AWS.Region))
+
+	checks = append(checks, checkSSHKey(cfg.AWS.KeyPath))
+
+	binDir := filepath.Join(repoRoot, "binaries")
+	checks = append(checks, checkBinary(binDir, cfg.VMware.VCDBinGlob, cfg.VMware.VCDBinMD5, "VCD installer (.bin)"))
+	checks = append(checks, checkBinary(binDir, cfg.VMware.OSERPMGlob, cfg.VMware.OSERPMMD5, "OSE package (.rpm)"))
+
+	return checks
+}
+
+// installHint returns a package-manager hint matching the host OS.
+func installHint(pkg, docURL string) string {
+	switch runtime.GOOS {
+	case "darwin":
+		return fmt.Sprintf("brew install %s (or see %s)", pkg, docURL)
+	case "linux":
+		return fmt.Sprintf("install %s with your distro's package manager (apt/dnf), or see %s", pkg, docURL)
+	default:
+		return fmt.Sprintf("install %s — see %s", pkg, docURL)
+	}
+}
+
+func checkTool(name, action string) Check {
+	if _, err := exec.LookPath(name); err != nil {
+		return Check{
+			Name:   name + " on PATH",
+			OK:     false,
+			Detail: "not found",
+			Action: action,
+		}
+	}
+	return Check{Name: name + " on PATH", OK: true}
+}
+
+func checkAWSCreds(profile, region string) Check {
+	if _, err := exec.LookPath("aws"); err != nil {
+		return Check{Name: "AWS credentials", OK: false, Detail: "aws CLI not installed", Action: installHint("awscli", "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html") + ", then aws sso login"}
+	}
+	args := []string{"sts", "get-caller-identity", "--region", region}
+	if profile != "" {
+		args = append(args, "--profile", profile)
+	}
+	cmd := exec.Command("aws", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		hint := "Run `aws sso login` (or configure credentials another way) and retry."
+		if profile != "" {
+			hint = fmt.Sprintf("Run `aws sso login --profile %s` and retry.", profile)
+		}
+		return Check{
+			Name:   "AWS credentials",
+			OK:     false,
+			Detail: strings.TrimSpace(string(out)),
+			Action: hint,
+		}
+	}
+	return Check{Name: "AWS credentials (profile " + profile + ")", OK: true}
+}
+
+func checkSSHKey(path string) Check {
+	if path == "" {
+		return Check{Name: "SSH key", OK: false, Detail: "aws.key_path is empty", Action: "Set aws.key_path in configs/lab.yaml."}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return Check{Name: "SSH key", OK: false, Detail: err.Error(), Action: fmt.Sprintf("Place the EC2 key pair PEM at %s.", path)}
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return Check{
+			Name:   "SSH key",
+			OK:     false,
+			Detail: fmt.Sprintf("%s has permissions %v (too open)", path, info.Mode().Perm()),
+			Action: fmt.Sprintf("Run `chmod 600 %s`.", path),
+		}
+	}
+	return Check{Name: "SSH key", OK: true}
+}
+
+func checkBinary(dir, glob, expectedMD5, label string) Check {
+	if glob == "" {
+		return Check{Name: label, OK: false, Detail: "glob not configured", Action: "Set vmware.* in configs/lab.yaml."}
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, glob))
+	if err != nil {
+		return Check{
+			Name:   label,
+			OK:     false,
+			Detail: fmt.Sprintf("malformed glob %q: %v", glob, err),
+			Action: "Fix the vmware.* glob pattern in configs/lab.yaml.",
+		}
+	}
+	if len(matches) == 0 {
+		return Check{
+			Name:   label,
+			OK:     false,
+			Detail: fmt.Sprintf("no file matching %s in binaries/", glob),
+			Action: fmt.Sprintf("Download the %s from Scality Drive (see binaries/README.md) and place it in dev/vcd-ose-lab/binaries/.", label),
+		}
+	}
+	if len(matches) > 1 {
+		return Check{Name: label, OK: false, Detail: "multiple matches: " + strings.Join(matches, ", "), Action: "Keep only one matching file in binaries/."}
+	}
+	if expectedMD5 != "" {
+		sum, err := md5File(matches[0])
+		if err != nil {
+			return Check{Name: label, OK: false, Detail: err.Error(), Action: "Check file permissions on binaries/."}
+		}
+		if !strings.EqualFold(sum, expectedMD5) {
+			return Check{
+				Name:   label,
+				OK:     false,
+				Detail: fmt.Sprintf("md5 %s != expected %s", sum, expectedMD5),
+				Action: "Re-download the binary or update the expected md5 in configs/lab.yaml.",
+			}
+		}
+	}
+	return Check{Name: label, OK: true, Detail: filepath.Base(matches[0])}
+}
+
+func md5File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/dev/vcd-ose-lab/internal/sshx/sshx.go
+++ b/dev/vcd-ose-lab/internal/sshx/sshx.go
@@ -1,0 +1,1 @@
+package sshx

--- a/dev/vcd-ose-lab/magefile.go
+++ b/dev/vcd-ose-lab/magefile.go
@@ -1,0 +1,60 @@
+//go:build mage
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/scality/osis/dev/vcd-ose-lab/internal/awsx"
+	"github.com/scality/osis/dev/vcd-ose-lab/internal/config"
+	"github.com/scality/osis/dev/vcd-ose-lab/internal/preflight"
+)
+
+func Preflight() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	checks := preflight.Run(wd)
+	failed := 0
+	for _, c := range checks {
+		mark := "[OK]"
+		if !c.OK {
+			mark = "[FAIL]"
+			failed++
+		}
+		line := fmt.Sprintf("%s %s", mark, c.Name)
+		if c.Detail != "" {
+			line += "  (" + c.Detail + ")"
+		}
+		fmt.Println(line)
+		if !c.OK && c.Action != "" {
+			fmt.Println("       -> " + c.Action)
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d preflight check(s) failed", failed)
+	}
+	return nil
+}
+
+// Tfvars renders configs/lab.yaml into terraform/terraform.tfvars.
+func Tfvars() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	cfg, err := config.Load(filepath.Join(wd, "configs", "lab.yaml"))
+	if err != nil {
+		return err
+	}
+	tfDir := filepath.Join(wd, "terraform")
+	if err := awsx.WriteTfvars(tfDir, cfg); err != nil {
+		return err
+	}
+	fmt.Println("wrote", filepath.Join(tfDir, "terraform.tfvars"))
+	return nil
+}
+

--- a/dev/vcd-ose-lab/scripts/local/build-osis-jar.sh
+++ b/dev/vcd-ose-lab/scripts/local/build-osis-jar.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Runs on the dev machine (Mac or Linux). Builds the OSIS jar with Java 17 (the
+# project requires it; default Java 18 fails with a "consumer needed a runtime
+# ... compatible with Java 17" error). Stubs out Sonatype publish creds so the
+# upload-artifact script doesn't blow up evaluating the gradle build file.
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/platform.sh"
+
+# Default to the repo this script lives in (dev/vcd-ose-lab/scripts/local/build-osis-jar.sh
+# → repo root is four levels up). Override via OSIS_REPO if the script is copied
+# elsewhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OSIS_REPO="${OSIS_REPO:-$(cd "${SCRIPT_DIR}/../../../.." && pwd)}"
+
+JAVA17_HOME="$(detect_java17_home)"
+export JAVA_HOME="${JAVA17_HOME}"
+export PATH="${JAVA_HOME}/bin:${PATH}"
+
+cd "${OSIS_REPO}"
+./gradlew bootJar -x test \
+    -PsonatypeUsername=x -PsonatypePassword=x \
+    --console=plain
+
+ls -la "${OSIS_REPO}/build/libs/"

--- a/dev/vcd-ose-lab/scripts/local/lib/platform.sh
+++ b/dev/vcd-ose-lab/scripts/local/lib/platform.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Shared helpers for dev-machine scripts. Source via:
+#   . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/platform.sh"
+#
+# Provides:
+#   detect_os                  -> echoes "mac" | "linux-debian" | "linux-rhel" | "linux"
+#   detect_java17_home         -> echoes JAVA_HOME for a JDK 17 installation, or fails with a clear install hint
+#   ngrok_config_path          -> echoes the per-platform default ngrok.yml path
+#   package_install_hint <tool>-> echoes "<pkgmgr> install <pkg>" tailored to the dev box
+#   ca_trust_commands <pem>    -> echoes the per-platform commands to system-trust a PEM cert
+#
+# Plain bash, no external deps beyond uname / readlink / basename.
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) echo "mac"; return ;;
+        Linux)
+            if [ -r /etc/os-release ]; then
+                # shellcheck disable=SC1091
+                . /etc/os-release
+                case "${ID_LIKE:-$ID}" in
+                    *debian*|*ubuntu*) echo "linux-debian"; return ;;
+                    *rhel*|*fedora*|*centos*) echo "linux-rhel"; return ;;
+                esac
+            fi
+            echo "linux"
+            ;;
+        *) echo "unsupported" ;;
+    esac
+}
+
+detect_java17_home() {
+    # Priority 1: caller already set JAVA_HOME and it's a JDK 17.
+    if [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME}/bin/java" ]; then
+        local v
+        v=$("${JAVA_HOME}/bin/java" -version 2>&1 | head -1)
+        if echo "$v" | grep -qE 'version "17\.'; then
+            echo "$JAVA_HOME"
+            return 0
+        fi
+    fi
+
+    # Priority 2: macOS Homebrew.
+    if [ "$(detect_os)" = "mac" ] && command -v brew >/dev/null 2>&1; then
+        local prefix
+        prefix=$(brew --prefix openjdk@17 2>/dev/null || true)
+        if [ -n "$prefix" ] && [ -d "$prefix/libexec/openjdk.jdk/Contents/Home" ]; then
+            echo "$prefix/libexec/openjdk.jdk/Contents/Home"
+            return 0
+        fi
+    fi
+
+    # Priority 3: standard Linux paths.
+    local candidate
+    for pattern in \
+        '/usr/lib/jvm/java-17-openjdk'* \
+        '/usr/lib/jvm/jdk-17'* \
+        '/usr/lib/jvm/temurin-17'* \
+        '/usr/lib/jvm/zulu-17'* \
+        '/opt/java/openjdk-17'*; do
+        for candidate in $pattern; do
+            if [ -d "$candidate" ] && [ -x "$candidate/bin/java" ]; then
+                echo "$candidate"
+                return 0
+            fi
+        done
+    done
+
+    echo "JDK 17 not found." >&2
+    echo "Install hint: $(package_install_hint 'openjdk-17')" >&2
+    return 1
+}
+
+ngrok_config_path() {
+    case "$(detect_os)" in
+        mac) echo "$HOME/Library/Application Support/ngrok/ngrok.yml" ;;
+        *)   echo "$HOME/.config/ngrok/ngrok.yml" ;;
+    esac
+}
+
+package_install_hint() {
+    local tool="$1"
+    case "$(detect_os)" in
+        mac)
+            case "$tool" in
+                openjdk-17) echo "brew install openjdk@17" ;;
+                tmux|terraform|rclone|jq|redis|ngrok) echo "brew install $tool" ;;
+                *) echo "brew install $tool" ;;
+            esac
+            ;;
+        linux-debian)
+            case "$tool" in
+                openjdk-17) echo "sudo apt install openjdk-17-jdk" ;;
+                terraform) echo "follow https://developer.hashicorp.com/terraform/install#linux for apt repo, then sudo apt install terraform" ;;
+                ngrok) echo "follow https://ngrok.com/download for the .deb package" ;;
+                redis) echo "sudo apt install redis-server" ;;
+                *) echo "sudo apt install $tool" ;;
+            esac
+            ;;
+        linux-rhel)
+            case "$tool" in
+                openjdk-17) echo "sudo dnf install java-17-openjdk-devel" ;;
+                terraform) echo "sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo && sudo dnf install terraform" ;;
+                ngrok) echo "follow https://ngrok.com/download for the .rpm package" ;;
+                redis) echo "sudo dnf install redis" ;;
+                *) echo "sudo dnf install $tool" ;;
+            esac
+            ;;
+        *)
+            echo "install $tool via your package manager"
+            ;;
+    esac
+}
+
+# Print the per-platform commands to system-trust a PEM cert. Caller substitutes
+# the actual path. Linux: Firefox uses its own NSS store, import manually there
+# if you use Firefox.
+ca_trust_commands() {
+    local pem="${1:-<path-to.pem>}"
+    case "$(detect_os)" in
+        mac)
+            echo "sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain $pem"
+            ;;
+        linux-debian)
+            echo "sudo cp $pem /usr/local/share/ca-certificates/$(basename "$pem" .pem).crt"
+            echo "sudo update-ca-certificates"
+            ;;
+        linux-rhel)
+            echo "sudo cp $pem /etc/pki/ca-trust/source/anchors/$(basename "$pem")"
+            echo "sudo update-ca-trust"
+            ;;
+        *)
+            echo "# add $pem to the system trust store using your distribution's tooling"
+            ;;
+    esac
+}

--- a/dev/vcd-ose-lab/scripts/local/setup-redis-sentinels.sh
+++ b/dev/vcd-ose-lab/scripts/local/setup-redis-sentinels.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Runs on the dev machine (Mac or Linux). Starts three Redis sentinels monitoring localhost:6379
+# (the master). OSIS hardcodes Redis Sentinel mode and won't accept plain
+# standalone Redis (see SpringRedisConfig.java).
+#
+# Idempotent: kills any existing sentinel on 26379/26380/26381 before
+# starting fresh.
+
+set -euo pipefail
+
+DIR="${OSIS_LOCAL_DIR:-/tmp/osis-local}/sentinels"
+mkdir -p "${DIR}"
+
+for p in 26379 26380 26381; do
+    pidfile="${DIR}/sentinel-${p}.pid"
+    # Stop whatever holds the port, not just what the pidfile knows about
+    # (the pidfile can be stale or gone while a sentinel still runs).
+    redis-cli -p "${p}" shutdown nosave 2>/dev/null || true
+    if [ -f "${pidfile}" ]; then
+        oldpid="$(cat "${pidfile}")"
+        kill "${oldpid}" 2>/dev/null || true
+        # Wait for the old process to release the socket: daemonized redis
+        # exits 0 before binding, so starting the replacement too early
+        # fails silently (the bind error only lands in the logfile).
+        for _ in $(seq 1 50); do
+            kill -0 "${oldpid}" 2>/dev/null || break
+            sleep 0.1
+        done
+        rm -f "${pidfile}"
+    fi
+
+    cat > "${DIR}/sentinel-${p}.conf" <<EOF
+port ${p}
+dir ${DIR}
+pidfile ${pidfile}
+logfile ${DIR}/sentinel-${p}.log
+sentinel monitor mymaster 127.0.0.1 6379 2
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 60000
+sentinel parallel-syncs mymaster 1
+EOF
+
+    redis-sentinel "${DIR}/sentinel-${p}.conf" --daemonize yes
+done
+
+sleep 1
+for p in 26379 26380 26381; do
+    printf 'sentinel %s: ' "${p}"
+    redis-cli -p "${p}" ping
+done

--- a/dev/vcd-ose-lab/scripts/vm/build-pkcs12-from-vcd-cert.sh
+++ b/dev/vcd-ose-lab/scripts/vm/build-pkcs12-from-vcd-cert.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Runs on the VM as root. Builds a PKCS#12 from the VCD-generated cert.pem /
+# cert.key and imports it as OSE's server keystore.
+#
+# CERT_PASSPHRASE must be supplied via env (no default). It's passed to
+# openssl via `env:` so it never appears in argv / /proc/<pid>/cmdline.
+#
+# Two fixes vs the Confluence doc:
+#   - The doc omits `-passin`, so openssl prompts for the input key passphrase
+#     and the script hangs (doc gap #10).
+#   - The doc uses `-name <IP>`. Using the FQDN as friendly-name keeps the
+#     keystore alias aligned with the cert CN, which keeps browser trust
+#     consistent once the OSE endpoint URL is switched to the FQDN (doc gap #13).
+
+set -euo pipefail
+
+: "${CERT_PASSPHRASE:?CERT_PASSPHRASE must be set in the environment}"
+
+FQDN=$(hostname -f)
+
+# openssl reads `env:VAR` for both -passin and -passout. The value is taken
+# from the environment, not the command line, so it stays out of process
+# listings.
+export CERT_PASSPHRASE
+
+cd /root
+openssl pkcs12 -export -out cert-fqdn.p12 \
+    -inkey /opt/vmware/vcloud-director/cert.key \
+    -in /opt/vmware/vcloud-director/cert.pem \
+    -passin env:CERT_PASSPHRASE \
+    -password env:CERT_PASSPHRASE \
+    -name "${FQDN}"
+
+ls -la /root/cert-fqdn.p12
+
+# ose cert import still takes --secret on argv. Pass via stdin if/when
+# the OSE CLI grows a stdin option; for now this is unavoidable.
+ose cert import --path /root/cert-fqdn.p12 --secret "${CERT_PASSPHRASE}" --force

--- a/dev/vcd-ose-lab/scripts/vm/fix-vcd-public-urls.sh
+++ b/dev/vcd-ose-lab/scripts/vm/fix-vcd-public-urls.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Runs on the VM as root, after cell-management-tool system-setup.
+# system-setup leaves the sites table with empty rest_api_endpoint /
+# base_ui_endpoint / multisite_url, which causes the H5 UI to throw
+# "Failed to Start" at /provider. Populate them with the FQDN URL, then
+# restart vmware-vcd so the H5 UI picks the values up.
+#
+# Doc gap #9.
+
+set -euo pipefail
+
+FQDN=$(hostname -f)
+echo "Setting VCD public endpoints to https://${FQDN}"
+
+# Pass the FQDN via psql -v so it is quoted server-side instead of
+# shell-interpolated into the SQL.
+result="$(sudo -u postgres psql -d vcddb -v ON_ERROR_STOP=1 -v fqdn="${FQDN}" <<'SQL'
+UPDATE sites SET
+    rest_api_endpoint = 'https://' || :'fqdn',
+    multisite_url     = 'https://' || :'fqdn',
+    base_ui_endpoint  = 'https://' || :'fqdn',
+    name              = 'VCD'
+WHERE is_local_site = true
+RETURNING name, rest_api_endpoint, base_ui_endpoint;
+SQL
+)"
+printf '%s\n' "${result}"
+
+# UPDATE 0 exits 0 — assert the local-site row actually existed, or the
+# "Failed to Start" condition this script exists to fix persists silently.
+if ! grep -q '^UPDATE 1' <<< "${result}"; then
+    echo "ERROR: no local site row updated — run this after cell-management-tool system-setup." >&2
+    exit 1
+fi
+
+echo 'Restarting vmware-vcd...'
+systemctl restart vmware-vcd
+
+echo 'Waiting for port 443 to come back...'
+for _ in {1..60}; do
+    sleep 5
+    if ss -tln | grep -q ':443 '; then
+        echo 'VCD listening on 443.'
+        exit 0
+    fi
+done
+
+echo 'WARNING: vmware-vcd did not start listening on 443 within ~5 min.' >&2
+exit 1

--- a/dev/vcd-ose-lab/scripts/vm/install-vmware-vcd-systemd-unit.sh
+++ b/dev/vcd-ose-lab/scripts/vm/install-vmware-vcd-systemd-unit.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Runs on the VM as root. The VCD installer skips creating the systemd unit
+# on Rocky 9 because /sbin/chkconfig is absent. This script writes the unit,
+# runs daemon-reload, and enables it. Assumes `initscripts` is already
+# installed so the VCD init script can source /etc/init.d/functions.
+
+set -euo pipefail
+
+cat > /etc/systemd/system/vmware-vcd.service <<'EOF'
+[Unit]
+Description=VMware Cloud Director
+After=network.target postgresql.service
+Wants=postgresql.service
+
+[Service]
+Type=forking
+ExecStart=/opt/vmware/vcloud-director/bin/vmware-vcd start
+ExecStop=/opt/vmware/vcloud-director/bin/vmware-vcd stop
+ExecReload=/opt/vmware/vcloud-director/bin/vmware-vcd restart
+RemainAfterExit=yes
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable vmware-vcd
+echo 'vmware-vcd.service installed and enabled. Start with: systemctl start vmware-vcd'

--- a/dev/vcd-ose-lab/scripts/vm/postgres-setup.sh
+++ b/dev/vcd-ose-lab/scripts/vm/postgres-setup.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Runs on the VM as root. Initializes PostgreSQL, applies a lab-grade
+# pg_hba.conf (local-only with scram-sha-256 — VCD and OSE live on the
+# same host as PG), patches postgresql.conf, starts the service, and
+# creates the two roles + databases (osedb with C collation, required
+# by OSE).
+#
+# PG_PASSWORD must be supplied via env (no default). Single quotes inside
+# the value are safe — we pass it via psql's `-v` variable substitution
+# (the `:'password'` form) which quotes correctly.
+
+set -euo pipefail
+
+: "${PG_PASSWORD:?PG_PASSWORD must be set in the environment}"
+
+if [ ! -f /var/lib/pgsql/data/PG_VERSION ]; then
+    postgresql-setup --initdb
+fi
+
+cat > /var/lib/pgsql/data/pg_hba.conf <<'EOF'
+local   all             all                                     peer
+host    all             all             127.0.0.1/32            scram-sha-256
+host    all             all             ::1/128                 scram-sha-256
+EOF
+
+sed -i "s/#listen_addresses = 'localhost'/listen_addresses = 'localhost'/" /var/lib/pgsql/data/postgresql.conf
+sed -i "s/max_connections = 100[[:space:]]*# (change requires restart)/max_connections = 300/" /var/lib/pgsql/data/postgresql.conf
+sed -i "s/#superuser_reserved_connections = 3[[:space:]]*# (change requires restart)/superuser_reserved_connections = 90/" /var/lib/pgsql/data/postgresql.conf
+sed -i "s/#password_encryption = scram-sha-256/password_encryption = scram-sha-256/" /var/lib/pgsql/data/postgresql.conf
+
+systemctl enable --now postgresql
+
+nc -vz localhost 5432
+
+# The scram-only pg_hba.conf and the psql features below assume PG 15
+# (the spin-up workflow enables the postgresql:15 module). On an older
+# server the password_encryption sed above silently no-ops and every
+# host login would be rejected — fail fast instead.
+server_num="$(sudo -u postgres psql -tAc 'show server_version_num')"
+if [ "${server_num}" -lt 150000 ]; then
+    echo "ERROR: PostgreSQL 15+ required (server_version_num=${server_num})." >&2
+    echo "Run: dnf module enable postgresql:15 -y && dnf install -y postgresql-server" >&2
+    exit 1
+fi
+
+# Use psql's `-v` to pass the password and `:'name'` substitution to
+# quote/escape it safely — no shell interpolation into the SQL. The
+# substitution must happen at the top level (psql skips it inside
+# dollar-quoted DO blocks), so build each CREATE USER with format(%L)
+# and run it via \gexec.
+sudo -u postgres psql -v ON_ERROR_STOP=1 -v password="${PG_PASSWORD}" <<'SQL'
+SELECT format('CREATE USER vcdadmin WITH PASSWORD %L LOGIN', :'password')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'vcdadmin') \gexec
+SELECT format('CREATE USER oseadmin WITH PASSWORD %L LOGIN', :'password')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'oseadmin') \gexec
+-- Re-runs with a different PG_PASSWORD must take effect, not silently
+-- keep the old one.
+SELECT format('ALTER USER vcdadmin WITH PASSWORD %L', :'password') \gexec
+SELECT format('ALTER USER oseadmin WITH PASSWORD %L', :'password') \gexec
+SQL
+
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='vcddb'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE DATABASE vcddb OWNER vcdadmin;"
+# OSE requires C collation. Set it at creation time (TEMPLATE template0 is
+# required when the collation differs from the server default) — updating
+# pg_database after the fact only rewrites catalog metadata.
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='osedb'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE DATABASE osedb OWNER oseadmin LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;"
+
+echo '--- post-setup ---'
+sudo -u postgres psql -c "\l" | grep -E '(vcddb|osedb)'

--- a/dev/vcd-ose-lab/scripts/vm/wire-osis.sh
+++ b/dev/vcd-ose-lab/scripts/vm/wire-osis.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Runs on the VM as root. Wires OSE to OSIS + S3 endpoints.
+#
+# Required env vars:
+#   OSIS_URL              public URL of the OSIS instance
+#   S3_URL                public URL of the S3 (Cloudserver) instance
+#   OSIS_ACCESS_KEY       OSIS super-admin access key
+#   OSIS_SECRET_KEY       OSIS super-admin secret key
+#
+# Secrets are passed via env so they don't appear in argv / /proc/<pid>/cmdline.
+# `ose osis admin set` is interactive (asks for the secret, then a y/N for the
+# password-complexity warning). We feed both via stdin.
+
+set -euo pipefail
+
+: "${OSIS_URL:?OSIS_URL must be set}"
+: "${S3_URL:?S3_URL must be set}"
+: "${OSIS_ACCESS_KEY:?OSIS_ACCESS_KEY must be set}"
+: "${OSIS_SECRET_KEY:?OSIS_SECRET_KEY must be set}"
+
+printf '%s\ny\n' "${OSIS_SECRET_KEY}" | \
+    ose osis admin set --name scality --url "${OSIS_URL}" --user "${OSIS_ACCESS_KEY}"
+
+ose osis s3 set --name scality --url "${S3_URL}"
+ose platforms enable osis --name scality
+ose service restart
+
+echo '--- validating ---'
+ose config validate

--- a/dev/vcd-ose-lab/terraform/main.tf
+++ b/dev/vcd-ose-lab/terraform/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+data "aws_ami" "rocky" {
+  most_recent = true
+  owners      = [var.rocky_ami_owner]
+  filter {
+    name   = "name"
+    values = [var.rocky_ami_name_pattern]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "lab" {
+  ami                         = var.ami_id_override != "" ? var.ami_id_override : data.aws_ami.rocky.id
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = var.security_group_ids
+  associate_public_ip_address = false
+
+  root_block_device {
+    volume_size           = var.root_volume_gb
+    volume_type           = var.root_volume_type
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  # IMDSv2 only — IMDSv1 is vulnerable to SSRF-based credential theft.
+  metadata_options {
+    http_tokens                 = "required"
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 1
+  }
+
+  tags = {
+    Name    = "vcd-ose-lab"
+    Project = "OSIS-VCD-Lab"
+  }
+}

--- a/dev/vcd-ose-lab/terraform/outputs.tf
+++ b/dev/vcd-ose-lab/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "instance_id" {
+  value = aws_instance.lab.id
+}
+
+output "private_ip" {
+  value = aws_instance.lab.private_ip
+}
+
+output "ami_id" {
+  value = aws_instance.lab.ami
+}

--- a/dev/vcd-ose-lab/terraform/variables.tf
+++ b/dev/vcd-ose-lab/terraform/variables.tf
@@ -1,0 +1,52 @@
+variable "aws_profile" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "security_group_ids" {
+  type = list(string)
+}
+
+variable "key_name" {
+  type = string
+}
+
+variable "instance_type" {
+  type    = string
+  default = "c5.4xlarge"
+}
+
+variable "root_volume_gb" {
+  type    = number
+  default = 400
+}
+
+variable "root_volume_type" {
+  type    = string
+  default = "gp2"
+}
+
+# Rocky AMI lookup. Defaults target Rocky 9 community AMIs published by
+# Rocky Enterprise Software Foundation. Override ami_id_override during the
+# ride-along once a working AMI is confirmed for the chosen region.
+variable "rocky_ami_owner" {
+  type    = string
+  default = "792107900819"
+}
+
+variable "rocky_ami_name_pattern" {
+  type    = string
+  default = "Rocky-9-EC2-Base-*"
+}
+
+variable "ami_id_override" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
## Intent: why does this change exist?

OSIS engineers need to spin up VMware Cloud Director + OSE on demand to test integration changes against a real VCD instance, but the manual process (Confluence page id 2138571097) is ~half a day and full of undocumented Rocky-9 + OSE-3.0 gotchas. This adds an agent-invocable skill that brings the lab up end-to-end against the engineer's local OSIS/Vault/Cloudserver (exposed via ngrok) and captures the 14 doc deltas we hit while debugging.

## System impact: what's affected, including downstream?

New top-level `dev/vcd-ose-lab/` workspace (Terraform module, preflight + tfvars Mage targets, install/wiring bash scripts) and a new `.claude/skills/vcd-ose-lab/` (router SKILL.md + five workflows + four references). No Java source changes — an earlier `CryptoEnv.java` path-override experiment was reverted; local dev places `crypto.yml` at `/conf/` as before.

## Preserved behavior: what explicitly stays the same?

Service code, Gradle build, JaCoCo coverage gate, all existing CI workflows, and the Docker image's `/conf/crypto.yml` mount contract are untouched.

## Intended change: what's different after this PR?

A clone-and-run lab: `cd dev/vcd-ose-lab && mage preflight` lists missing prereqs with actionable fixes, the skill then drives `terraform apply`, SSHs into a shared `tmux` session on the VM, and walks the Confluence sequence with all the Rocky-9 / OSE-3.0 fixes baked in (postgresql:15, missing systemd unit, sites-table fix for the H5 UI, FQDN-everywhere cert trust, OSE 3.0 EULA + cert-prompt handling). All secrets (postgres password, cert passphrase, OSIS keys) are required inputs via `lab.yaml`/env — no weak defaults — and scripts keep them out of argv. Terraform enforces EBS encryption + IMDSv2.

## Verification: how do we know this worked, or how would we know if it didn't?

End-to-end ride-along on 2026-05-28: `terraform apply` ⇒ 13s, full provision + wiring ⇒ ~30 min, `ose config validate` shows all seven rows Valid, the VCD `/provider` UI loads at the FQDN, and S3 credential create succeeds. The hardened postgres script's psql `\gexec` quoting was syntax-checked; capture artifacts with real infra identifiers were removed from the branch and gitignored.

Note to reviewers: For some reason my commits are unverified, I will recommit before merging.
