### PR TITLE
OSIS-161: extract the encrypted secret-key store as a deep module

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/credentials/EncryptedSecretKeyStore.java
+++ b/osis-core/src/main/java/com/scality/osis/service/credentials/EncryptedSecretKeyStore.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+import com.scality.osis.security.crypto.model.SecretKeyRepoData;
+import com.scality.osis.security.utils.CipherFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link SecretKeyStore} that encrypts with {@link CipherFactory} (AES-GCM, {@code repoKey} as
+ * associated data) and persists through a {@link SecretKeyBackend}.
+ *
+ * <p>Each stored record is stamped with the id and name of the cipher key that encrypted it, so a
+ * later retrieve can pick the matching key even across key rotation. If decryption fails the record
+ * is treated as unrecoverable: it is evicted and {@code null} is returned.</p>
+ */
+public class EncryptedSecretKeyStore implements SecretKeyStore {
+
+    private static final Logger logger = LoggerFactory.getLogger(EncryptedSecretKeyStore.class);
+
+    private final SecretKeyBackend backend;
+    private final CipherFactory cipherFactory;
+
+    public EncryptedSecretKeyStore(SecretKeyBackend backend, CipherFactory cipherFactory) {
+        this.backend = backend;
+        this.cipherFactory = cipherFactory;
+    }
+
+    @Override
+    public void store(String repoKey, String secret) throws Exception {
+        // Using `repoKey` for Associated Data during encryption
+        logger.debug("Store Secret Key. Key:{}", repoKey);
+        SecretKeyRepoData encryptedRepoData = cipherFactory.getCipher().encrypt(secret,
+                cipherFactory.getLatestSecretCipherKey(),
+                repoKey);
+
+        // Stamp the record with the encrypting key's id/name so retrieve can pick the matching key.
+        encryptedRepoData.setKeyID(cipherFactory.getLatestCipherID());
+        encryptedRepoData.getCipherInfo().setCipherName(cipherFactory.getLatestCipherName());
+
+        backend.save(repoKey, encryptedRepoData);
+        logger.debug("Store Secret Key successful. Key:{}", repoKey);
+    }
+
+    @Override
+    public String retrieve(String repoKey) throws Exception {
+        logger.debug("Retrieve Secret Key. Key:{}", repoKey);
+        SecretKeyRepoData repoVal = backend.get(repoKey);
+
+        String secretKey = null;
+
+        if (repoVal != null) {
+            try {
+                // Using `repoKey` for Associated Data during decryption
+                secretKey = cipherFactory.getCipherByID(repoVal.getKeyID())
+                        .decrypt(repoVal,
+                                cipherFactory.getSecretCipherKeyByID(repoVal.getKeyID()),
+                                repoKey);
+
+                logger.debug("Retrieve Secret Key successful. Key:{}", repoKey);
+            } catch (Exception e) {
+                logger.error("Error: Unable to decrypt secret key data for key: {}. Error details: {}", repoKey, e.getMessage());
+                logger.debug("Full stack trace:", e);
+                delete(repoKey);
+            }
+        }
+        return secretKey;
+    }
+
+    @Override
+    public void delete(String repoKey) throws Exception {
+        logger.debug("Delete Secret Key. Key:{}", repoKey);
+        backend.delete(repoKey);
+        logger.debug("Delete Secret Key successful. Key:{}", repoKey);
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/service/credentials/InMemorySecretKeyBackend.java
+++ b/osis-core/src/main/java/com/scality/osis/service/credentials/InMemorySecretKeyBackend.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+import com.scality.osis.security.crypto.model.SecretKeyRepoData;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Process-local {@link SecretKeyBackend} backed by a {@link ConcurrentHashMap}.
+ *
+ * <p>Used when Redis is not configured (i.e. {@code spring.cache.type} is not {@code redis}). Records
+ * live only for the lifetime of the JVM.</p>
+ */
+public class InMemorySecretKeyBackend implements SecretKeyBackend {
+
+    private final Map<String, SecretKeyRepoData> store = new ConcurrentHashMap<>();
+
+    @Override
+    public SecretKeyRepoData get(String repoKey) {
+        return store.get(repoKey);
+    }
+
+    @Override
+    public void save(String repoKey, SecretKeyRepoData value) {
+        store.put(repoKey, value);
+    }
+
+    @Override
+    public void delete(String repoKey) {
+        store.remove(repoKey);
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/service/credentials/RedisSecretKeyBackend.java
+++ b/osis-core/src/main/java/com/scality/osis/service/credentials/RedisSecretKeyBackend.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+import com.scality.osis.redis.service.IRedisRepository;
+import com.scality.osis.security.crypto.model.SecretKeyRepoData;
+
+/**
+ * {@link SecretKeyBackend} backed by Redis Sentinel via {@link IRedisRepository}.
+ *
+ * <p>Records land in the {@code osis:s3credentials} hash owned by the underlying repository.</p>
+ */
+public class RedisSecretKeyBackend implements SecretKeyBackend {
+
+    private final IRedisRepository<SecretKeyRepoData> redisRepository;
+
+    public RedisSecretKeyBackend(IRedisRepository<SecretKeyRepoData> redisRepository) {
+        this.redisRepository = redisRepository;
+    }
+
+    @Override
+    public SecretKeyRepoData get(String repoKey) {
+        return redisRepository.get(repoKey);
+    }
+
+    @Override
+    public void save(String repoKey, SecretKeyRepoData value) {
+        redisRepository.save(repoKey, value);
+    }
+
+    @Override
+    public void delete(String repoKey) {
+        redisRepository.delete(repoKey);
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/service/credentials/SecretKeyBackend.java
+++ b/osis-core/src/main/java/com/scality/osis/service/credentials/SecretKeyBackend.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+import com.scality.osis.security.crypto.model.SecretKeyRepoData;
+
+/**
+ * Raw key/value backing store for already-encrypted secret-key records.
+ *
+ * <p>This is the storage seam behind {@link SecretKeyStore}: it moves opaque
+ * {@link SecretKeyRepoData} blobs in and out by key and knows nothing about encryption. The two
+ * adapters are {@link RedisSecretKeyBackend} (Redis Sentinel) and {@link InMemorySecretKeyBackend}
+ * (process-local map); the active one is chosen in {@link SecretKeyStoreConfiguration}.</p>
+ *
+ * <p>Absence is signalled by {@link #get} returning {@code null}, and {@link #delete} is idempotent,
+ * so there is no separate existence check.</p>
+ */
+public interface SecretKeyBackend {
+
+    /**
+     * @param repoKey the storage key
+     * @return the stored record, or {@code null} if absent
+     */
+    SecretKeyRepoData get(String repoKey);
+
+    /**
+     * Store (or overwrite) the record for {@code repoKey}.
+     *
+     * @param repoKey the storage key
+     * @param value   the encrypted record to persist
+     */
+    void save(String repoKey, SecretKeyRepoData value);
+
+    /**
+     * Remove the record for {@code repoKey}. A no-op if the key is absent.
+     *
+     * @param repoKey the storage key
+     */
+    void delete(String repoKey);
+}

--- a/osis-core/src/main/java/com/scality/osis/service/credentials/SecretKeyStore.java
+++ b/osis-core/src/main/java/com/scality/osis/service/credentials/SecretKeyStore.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+/**
+ * Stores S3 secret access keys at rest, encrypted.
+ *
+ * <p>Callers hand over a plaintext secret together with a {@code repoKey} (the storage identity of
+ * the credential, e.g. {@code <userId>__<accessKeyId>}). The store owns the encryption invariant:
+ * the secret is encrypted before it leaves this boundary and decrypted only when retrieved, with
+ * {@code repoKey} bound in as the AES-GCM associated data. Whether the encrypted bytes live in Redis
+ * or in process memory is hidden behind a {@link SecretKeyBackend}.</p>
+ */
+public interface SecretKeyStore {
+
+    /**
+     * Encrypt {@code secret} (with {@code repoKey} as associated data) and persist it under
+     * {@code repoKey}.
+     *
+     * @param repoKey the storage identity of the credential, also used as encryption associated data
+     * @param secret  the plaintext secret access key to store
+     * @throws Exception if encryption or the backend write fails
+     */
+    void store(String repoKey, String secret) throws Exception;
+
+    /**
+     * Fetch and decrypt the secret stored under {@code repoKey}.
+     *
+     * <p>If no entry exists the result is {@code null}. If an entry exists but cannot be decrypted
+     * (e.g. cipher-key rotation made it unrecoverable), the entry is evicted and {@code null} is
+     * returned.</p>
+     *
+     * @param repoKey the storage identity of the credential
+     * @return the plaintext secret, or {@code null} when absent or undecryptable
+     * @throws Exception if the backend read or an eviction triggered by a decrypt failure fails
+     */
+    String retrieve(String repoKey) throws Exception;
+
+    /**
+     * Remove any secret stored under {@code repoKey}.
+     *
+     * @param repoKey the storage identity of the credential
+     * @throws Exception if the backend delete fails
+     */
+    void delete(String repoKey) throws Exception;
+}

--- a/osis-core/src/main/java/com/scality/osis/service/credentials/SecretKeyStoreConfiguration.java
+++ b/osis-core/src/main/java/com/scality/osis/service/credentials/SecretKeyStoreConfiguration.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+import com.scality.osis.ScalityAppEnv;
+import com.scality.osis.redis.service.IRedisRepository;
+import com.scality.osis.security.crypto.model.SecretKeyRepoData;
+import com.scality.osis.security.utils.CipherFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.scality.osis.utils.ScalityConstants.REDIS_SPRING_CACHE_TYPE;
+
+/**
+ * Wires the {@link SecretKeyStore}: picks the {@link SecretKeyBackend} from
+ * {@code spring.cache.type} (Redis when {@code redis}, otherwise process-local) and wraps it in an
+ * {@link EncryptedSecretKeyStore}.
+ */
+@Configuration
+public class SecretKeyStoreConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(SecretKeyStoreConfiguration.class);
+
+    @Bean
+    public SecretKeyBackend secretKeyBackend(ScalityAppEnv appEnv,
+                                             IRedisRepository<SecretKeyRepoData> redisRepository) {
+        if (REDIS_SPRING_CACHE_TYPE.equalsIgnoreCase(appEnv.getSpringCacheType())) {
+            logger.info("[SecretKeyStore] Using Redis backend for secret-key storage");
+            return new RedisSecretKeyBackend(redisRepository);
+        }
+        logger.info("[SecretKeyStore] Using in-memory backend for secret-key storage");
+        return new InMemorySecretKeyBackend();
+    }
+
+    @Bean
+    public SecretKeyStore secretKeyStore(SecretKeyBackend secretKeyBackend, CipherFactory cipherFactory) {
+        return new EncryptedSecretKeyStore(secretKeyBackend, cipherFactory);
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -21,12 +21,10 @@ import com.scality.osis.ScalityAppEnv;
 import com.scality.osis.model.*;
 import com.scality.osis.model.exception.NotFoundException;
 import com.scality.osis.model.exception.NotImplementedException;
-import com.scality.osis.redis.service.IRedisRepository;
 import com.scality.osis.resource.ScalityOsisCapsManager;
 import com.scality.osis.s3.S3;
-import com.scality.osis.security.crypto.model.SecretKeyRepoData;
-import com.scality.osis.security.utils.CipherFactory;
 import com.scality.osis.service.ScalityOsisService;
+import com.scality.osis.service.credentials.SecretKeyStore;
 import com.scality.osis.utapi.Utapi;
 import com.scality.osis.utapiclient.dto.ListMetricsRequestDTO;
 import com.scality.osis.utapiclient.dto.MetricsData;
@@ -47,7 +45,6 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static com.scality.osis.utils.ScalityConstants.*;
 import static com.scality.osis.utils.ScalityUtils.getHourTime;
@@ -70,12 +67,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
     private AsyncScalityOsisService asyncScalityOsisService;
 
     @Autowired
-    private IRedisRepository<SecretKeyRepoData> scalityRedisRepository;
-
-    @Autowired
-    private CipherFactory cipherFactory;
-
-    private final Map<String, SecretKeyRepoData> springLocalCache = new ConcurrentHashMap<>();
+    private SecretKeyStore secretKeyStore;
 
     /**
      * Instantiates a new Scality osis service.
@@ -534,7 +526,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             logger.debug("[Vault] Delete Access Key response:{}", new Gson().toJson(deleteAccessKeyResult));
 
-            deleteSecretKey(ScalityModelConverter.toRepoKeyForCredentials(userId, accessKey));
+            secretKeyStore.delete(ScalityModelConverter.toRepoKeyForCredentials(userId, accessKey));
 
             logger.info("Delete S3 credential successful:: tenant ID:{}, user ID:{}, accessKey:{}",
                     tenantId, userId, accessKey);
@@ -716,7 +708,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             if (accessKeyResult.isPresent()) {
                 AccessKeyMetadata accessKeyMetadata = accessKeyResult.get();
 
-                String secretKey = retrieveSecretKey(
+                String secretKey = secretKeyStore.retrieve(
                         ScalityModelConverter.toRepoKeyForCredentials(userId, accessKeyMetadata.getAccessKeyId()));
 
                 // get Osis User by userId
@@ -956,7 +948,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             Map<String, String> secretKeyMap = new HashMap<>();
             for (AccessKeyMetadata accessKey : listAccessKeysResult.getAccessKeyMetadata()) {
-                String secretKey = retrieveSecretKey(
+                String secretKey = secretKeyStore.retrieve(
                         ScalityModelConverter.toRepoKeyForCredentials(userId, accessKey.getAccessKeyId()));
                 if (!StringUtils.isNullOrEmpty(secretKey)) {
                     secretKeyMap.put(accessKey.getAccessKeyId(), secretKey);
@@ -1311,7 +1303,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
         logger.debug("[Vault] Create User Access Key Response:{}", createAccessKeyResult);
 
-        storeSecretKey(
+        secretKeyStore.store(
                 ScalityModelConverter.toRepoKeyForCredentials(userId,
                         createAccessKeyResult.getAccessKey().getAccessKeyId()),
                 createAccessKeyResult.getAccessKey().getSecretAccessKey());
@@ -1370,68 +1362,6 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 ||
                 (e instanceof UtapiClientException &&
                         (HttpStatus.FORBIDDEN.value() == ((UtapiClientException) e).getStatusCode()));
-    }
-
-    private void storeSecretKey(String repoKey, String secretAccessKey) throws Exception {
-        // Using `repoKey` for Associated Data during encryption
-        logger.debug("[Cache] Store Secret Key on cache. Key:{}", repoKey);
-        SecretKeyRepoData encryptedRepoData = cipherFactory.getCipher().encrypt(secretAccessKey,
-                cipherFactory.getLatestSecretCipherKey(),
-                repoKey);
-
-        encryptedRepoData.setKeyID(cipherFactory.getLatestCipherID());
-        encryptedRepoData.getCipherInfo().setCipherName(cipherFactory.getLatestCipherName());
-        // Prefix Cipher ID to the encrypted value
-
-        if (REDIS_SPRING_CACHE_TYPE.equalsIgnoreCase(appEnv.getSpringCacheType())) {
-            scalityRedisRepository.save(repoKey, encryptedRepoData);
-        } else {
-            springLocalCache.put(repoKey, encryptedRepoData);
-        }
-        logger.debug("[Cache] Store Secret Key successful");
-    }
-
-    private String retrieveSecretKey(String repoKey) throws Exception {
-        logger.debug("[Cache] Retrieve Secret Key from cache. Key:{}", repoKey);
-        SecretKeyRepoData repoVal = null;
-        if (REDIS_SPRING_CACHE_TYPE.equalsIgnoreCase(appEnv.getSpringCacheType())) {
-            if (scalityRedisRepository.hasKey(repoKey)) {
-                repoVal = scalityRedisRepository.get(repoKey);
-            }
-        } else {
-            repoVal = springLocalCache.get(repoKey);
-        }
-
-        String secretKey = null;
-
-        if (repoVal != null) {
-            try {
-                // Using `repoKey` for Associated Data during decryption
-                secretKey = cipherFactory.getCipherByID(repoVal.getKeyID())
-                        .decrypt(repoVal,
-                                cipherFactory.getSecretCipherKeyByID(repoVal.getKeyID()),
-                                repoKey);
-
-                logger.debug("[Cache] Retrieve Secret Key successful");
-            } catch (Exception e) {
-                logger.error("Error: Unable to decrypt secret key data for Redis key: {}. Error details: {}", repoKey, e.getMessage());
-                logger.debug("Full stack trace:", e);
-                deleteSecretKey(repoKey);
-            }
-        }
-        return secretKey;
-    }
-
-    private void deleteSecretKey(String repoKey) throws Exception {
-        logger.debug("[Cache] Delete Secret Key from cache. Key:{}", repoKey);
-        if (REDIS_SPRING_CACHE_TYPE.equalsIgnoreCase(appEnv.getSpringCacheType())) {
-            if (scalityRedisRepository.hasKey(repoKey)) {
-                scalityRedisRepository.delete(repoKey);
-            }
-        } else {
-            springLocalCache.remove(repoKey);
-        }
-        logger.debug("[Cache] Delete Secret Key from cache successful");
     }
 
     private Map<String, String> getTenantIdAndUserIdByAccessKeyFromVault(String accessKey) {

--- a/osis-core/src/test/java/com/scality/osis/service/credentials/EncryptedSecretKeyStoreTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/credentials/EncryptedSecretKeyStoreTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+import com.scality.osis.security.crypto.CryptoEnv;
+import com.scality.osis.security.crypto.model.SecretKeyRepoData;
+import com.scality.osis.security.utils.CipherFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static com.scality.osis.security.utils.SecurityConstants.NAME_AES_256_GCM_CIPHER;
+import static com.scality.osis.utils.ScalityTestUtils.TEST_CIPHER_ID;
+import static com.scality.osis.utils.ScalityTestUtils.TEST_CIPHER_SECRET_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Exercises {@link EncryptedSecretKeyStore} against the real {@link CipherFactory}/AES256GCM cipher
+ * and the {@link InMemorySecretKeyBackend}, so encryption, decryption, and on-decrypt-failure
+ * eviction are all genuinely run rather than mocked.
+ */
+class EncryptedSecretKeyStoreTest {
+
+    private static final String REPO_KEY = "user-1__AKIAEXAMPLE";
+    private static final String SECRET = "s3cr3t-access-key-value";
+
+    private InMemorySecretKeyBackend backend;
+    private SecretKeyStore secretKeyStore;
+
+    @BeforeEach
+    void setUp() {
+        backend = new InMemorySecretKeyBackend();
+
+        final CryptoEnv.CipherKey cipherKey = new CryptoEnv.CipherKey();
+        cipherKey.setId(TEST_CIPHER_ID);
+        cipherKey.setCipher(NAME_AES_256_GCM_CIPHER);
+        cipherKey.setSecretKey(TEST_CIPHER_SECRET_KEY);
+
+        final CryptoEnv cryptoEnv = new CryptoEnv();
+        cryptoEnv.setKeys(List.of(cipherKey));
+
+        final CipherFactory cipherFactory = new CipherFactory();
+        ReflectionTestUtils.setField(cipherFactory, "cryptoEnv", cryptoEnv);
+
+        secretKeyStore = new EncryptedSecretKeyStore(backend, cipherFactory);
+    }
+
+    @Test
+    void testStoreThenRetrieveReturnsOriginalSecret() throws Exception {
+        secretKeyStore.store(REPO_KEY, SECRET);
+
+        // The persisted record is encrypted, not the plaintext, and is stamped with the cipher id/name.
+        final SecretKeyRepoData stored = backend.get(REPO_KEY);
+        assertEquals(TEST_CIPHER_ID, stored.getKeyID());
+        assertEquals(NAME_AES_256_GCM_CIPHER, stored.getCipherInfo().getCipherName());
+        // AES-GCM ciphertext carries a 16-byte auth tag, so the stored bytes can't be the raw plaintext.
+        assertNotEquals(SECRET.getBytes(StandardCharsets.UTF_8).length, stored.getEncryptedBytes().length);
+
+        assertEquals(SECRET, secretKeyStore.retrieve(REPO_KEY));
+    }
+
+    @Test
+    void testRetrieveMissingKeyReturnsNull() throws Exception {
+        assertNull(secretKeyStore.retrieve("absent__key"));
+    }
+
+    @Test
+    void testRetrieveEvictsAndReturnsNullWhenDecryptionFails() throws Exception {
+        secretKeyStore.store(REPO_KEY, SECRET);
+
+        // Corrupt the stored ciphertext so AES-GCM authentication fails on decrypt.
+        final SecretKeyRepoData corrupted = backend.get(REPO_KEY);
+        corrupted.getEncryptedBytes()[0] ^= (byte) 0xFF;
+        backend.save(REPO_KEY, corrupted);
+
+        assertNull(secretKeyStore.retrieve(REPO_KEY));
+        // The undecryptable record must be evicted.
+        assertNull(backend.get(REPO_KEY));
+    }
+
+    @Test
+    void testRetrieveUsesRepoKeyAsAssociatedData() throws Exception {
+        secretKeyStore.store(REPO_KEY, SECRET);
+
+        // Re-home the same encrypted record under a different repoKey: the AAD no longer matches,
+        // so decryption fails, the entry is evicted, and null is returned.
+        final SecretKeyRepoData stored = backend.get(REPO_KEY);
+        final String otherKey = "user-2__AKIAOTHER";
+        backend.save(otherKey, stored);
+
+        assertNull(secretKeyStore.retrieve(otherKey));
+        assertNull(backend.get(otherKey));
+    }
+
+    @Test
+    void testDeleteRemovesStoredSecret() throws Exception {
+        secretKeyStore.store(REPO_KEY, SECRET);
+        assertNotNull(backend.get(REPO_KEY));
+
+        secretKeyStore.delete(REPO_KEY);
+
+        assertNull(backend.get(REPO_KEY));
+        assertNull(secretKeyStore.retrieve(REPO_KEY));
+    }
+}

--- a/osis-core/src/test/java/com/scality/osis/service/credentials/SecretKeyBackendTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/credentials/SecretKeyBackendTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+import com.scality.osis.redis.service.IRedisRepository;
+import com.scality.osis.security.crypto.model.SecretKeyRepoData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SecretKeyBackendTest {
+
+    private static final String REPO_KEY = "user-1__AKIAEXAMPLE";
+
+    @Mock
+    private IRedisRepository<SecretKeyRepoData> redisRepository;
+
+    private RedisSecretKeyBackend redisBackend;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        redisBackend = new RedisSecretKeyBackend(redisRepository);
+    }
+
+    @Test
+    void testRedisBackendDelegatesGetSaveDelete() {
+        final SecretKeyRepoData value = new SecretKeyRepoData();
+        when(redisRepository.get(REPO_KEY)).thenReturn(value);
+
+        assertSame(value, redisBackend.get(REPO_KEY));
+
+        redisBackend.save(REPO_KEY, value);
+        verify(redisRepository).save(REPO_KEY, value);
+
+        // Delete is unconditional: Redis HDEL on a missing field is already a no-op.
+        redisBackend.delete(REPO_KEY);
+        verify(redisRepository).delete(REPO_KEY);
+    }
+
+    @Test
+    void testRedisBackendGetReturnsNullWhenAbsent() {
+        when(redisRepository.get(REPO_KEY)).thenReturn(null);
+        assertNull(redisBackend.get(REPO_KEY));
+    }
+
+    @Test
+    void testInMemoryBackendStoresAndDeletes() {
+        final InMemorySecretKeyBackend backend = new InMemorySecretKeyBackend();
+        final SecretKeyRepoData value = new SecretKeyRepoData();
+
+        assertNull(backend.get(REPO_KEY));
+
+        backend.save(REPO_KEY, value);
+        assertSame(value, backend.get(REPO_KEY));
+
+        backend.delete(REPO_KEY);
+        assertNull(backend.get(REPO_KEY));
+    }
+}

--- a/osis-core/src/test/java/com/scality/osis/service/credentials/SecretKeyStoreConfigurationTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/credentials/SecretKeyStoreConfigurationTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.service.credentials;
+
+import com.scality.osis.ScalityAppEnv;
+import com.scality.osis.redis.service.IRedisRepository;
+import com.scality.osis.security.crypto.model.SecretKeyRepoData;
+import com.scality.osis.security.utils.CipherFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static com.scality.osis.utils.ScalityConstants.REDIS_SPRING_CACHE_TYPE;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.when;
+
+class SecretKeyStoreConfigurationTest {
+
+    @Mock
+    private ScalityAppEnv appEnv;
+
+    @Mock
+    private IRedisRepository<SecretKeyRepoData> redisRepository;
+
+    @Mock
+    private CipherFactory cipherFactory;
+
+    private SecretKeyStoreConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        configuration = new SecretKeyStoreConfiguration();
+    }
+
+    @Test
+    void selectsRedisBackendWhenCacheTypeIsRedis() {
+        when(appEnv.getSpringCacheType()).thenReturn(REDIS_SPRING_CACHE_TYPE);
+        assertInstanceOf(RedisSecretKeyBackend.class,
+                configuration.secretKeyBackend(appEnv, redisRepository));
+    }
+
+    @Test
+    void selectsInMemoryBackendWhenCacheTypeIsNotRedis() {
+        when(appEnv.getSpringCacheType()).thenReturn("simple");
+        assertInstanceOf(InMemorySecretKeyBackend.class,
+                configuration.secretKeyBackend(appEnv, redisRepository));
+    }
+
+    @Test
+    void buildsEncryptedSecretKeyStore() {
+        assertInstanceOf(EncryptedSecretKeyStore.class,
+                configuration.secretKeyStore(new InMemorySecretKeyBackend(), cipherFactory));
+    }
+}

--- a/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/BaseOsisServiceTest.java
@@ -18,6 +18,9 @@ import com.scality.osis.security.crypto.BaseCipher;
 import com.scality.osis.security.crypto.model.CipherInformation;
 import com.scality.osis.security.crypto.model.SecretKeyRepoData;
 import com.scality.osis.security.utils.CipherFactory;
+import com.scality.osis.service.credentials.EncryptedSecretKeyStore;
+import com.scality.osis.service.credentials.RedisSecretKeyBackend;
+import com.scality.osis.service.credentials.SecretKeyStore;
 import com.scality.osis.utapi.impl.UtapiImpl;
 import com.scality.osis.utapiclient.dto.MetricsData;
 import com.scality.osis.utapiclient.services.UtapiServiceClient;
@@ -103,8 +106,10 @@ class BaseOsisServiceTest {
 
         ReflectionTestUtils.setField(scalityOsisServiceUnderTest, "asyncScalityOsisService",
                 asyncScalityOsisServiceUnderTest);
-        ReflectionTestUtils.setField(scalityOsisServiceUnderTest, "scalityRedisRepository", redisRepositoryMock);
-        ReflectionTestUtils.setField(scalityOsisServiceUnderTest, "cipherFactory", cipherFactoryMock);
+
+        final SecretKeyStore secretKeyStore = new EncryptedSecretKeyStore(
+                new RedisSecretKeyBackend(redisRepositoryMock), cipherFactoryMock);
+        ReflectionTestUtils.setField(scalityOsisServiceUnderTest, "secretKeyStore", secretKeyStore);
     }
 
     protected void initMocks() {
@@ -174,7 +179,6 @@ class BaseOsisServiceTest {
 
     private void initRedisMocks() {
         when(redisRepositoryMock.get(any())).thenReturn(mockSecretKeyRepoData());
-        when(redisRepositoryMock.hasKey(any())).thenReturn(Boolean.TRUE);
     }
 
     private SecretKeyRepoData mockSecretKeyRepoData() {

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceCredentialsTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceCredentialsTests.java
@@ -153,6 +153,9 @@ class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest {
 
     }
 
+    // deleteS3Credential always delegates to the store; the store's delete is unconditional
+    // (an idempotent Redis HDEL, a no-op when the key is absent), so there is no existence
+    // check to assert here. The unconditional-delete contract is pinned in SecretKeyBackendTest.
     @Test
     void testDeleteS3Credential() {
         // Setup
@@ -163,19 +166,6 @@ class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest {
         // Verify the results
         verify(iamMock).deleteAccessKey(any(DeleteAccessKeyRequest.class));
         verify(redisRepositoryMock).delete(any());
-    }
-
-    @Test
-    void testDeleteS3CredentialWithNoKeyOnRedis() {
-        // Setup
-        when(redisRepositoryMock.hasKey(any())).thenReturn(Boolean.FALSE);
-
-        // Run the test
-        scalityOsisServiceUnderTest.deleteS3Credential(TEST_TENANT_ID, TEST_USER_ID, TEST_ACCESS_KEY);
-
-        // Verify the results
-        verify(iamMock).deleteAccessKey(any(DeleteAccessKeyRequest.class));
-        verify(redisRepositoryMock, never()).delete(any());
     }
 
     @Test
@@ -381,8 +371,8 @@ class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest {
 
     @Test
     void testGetS3CredentialWithNoKeyOnRedis() {
-        // Setup
-        when(redisRepositoryMock.hasKey(any())).thenReturn(Boolean.FALSE);
+        // Setup: the secret is absent from storage (Redis returns null for the lookup)
+        when(redisRepositoryMock.get(any())).thenReturn(null);
 
         // Run the test
         final OsisS3Credential result = scalityOsisServiceUnderTest.getS3Credential(SAMPLE_TENANT_ID, TEST_USER_ID,
@@ -485,8 +475,8 @@ class ScalityOsisServiceCredentialsTests extends BaseOsisServiceTest {
 
     @Test
     void testListS3CredentialsWithNoKeyOnRedis() {
-        // Setup
-        when(redisRepositoryMock.hasKey(any())).thenReturn(Boolean.FALSE);
+        // Setup: the secret is absent from storage (Redis returns null for the lookup)
+        when(redisRepositoryMock.get(any())).thenReturn(null);
 
         when(iamMock.listAccessKeys(any(ListAccessKeysRequest.class)))
                 .thenAnswer((Answer<ListAccessKeysResult>) invocation -> {


### PR DESCRIPTION
## Intent: why does this change exist?
The encrypted secret-key store was three private methods tangled inside the 1451-line `ScalityOsisServiceImpl`, each repeating the same encrypt + redis-vs-in-memory branch. Pulling it into a deep module gives the credential-storage invariant one owner and makes it testable on its own.

## System impact: what's affected, including downstream?
osis-core only. New package `com.scality.osis.service.credentials` (SecretKeyStore + a SecretKeyBackend port with Redis/in-memory adapters + a Spring `@Configuration`). `ScalityOsisServiceImpl` now depends on the `SecretKeyStore` bean instead of `CipherFactory` + `IRedisRepository` directly. No API, wire-format, or config-surface changes; same `osis:s3credentials` Redis hash.

## Preserved behavior: what explicitly stays the same?
Encrypt-then-store with `repoKey` as AES-GCM associated data, cipher-id versioning across key rotation, and evict-then-return-null on a decryption failure. AssumeRole flow, catch/logging, and the in-memory fallback all unchanged.

## Intended change: what's different after this PR?
Storage sits behind a three-method `SecretKeyStore` interface with the Redis/in-memory choice as an injected backend port selected by `spring.cache.type`. The redundant existence checks are gone - absence is `get()==null` and delete is idempotent - so the backend interface is just get/save/delete. (Net effect on the Redis delete path: an unconditional, idempotent HDEL instead of a hasKey-guarded one - same stored state.)

## Verification: how do we know this worked, or how would we know if it didn't?
Full `./gradlew build` is green (all tests + 75% JaCoCo + SpotBugs + PMD). New unit tests exercise the store against a real `CipherFactory`/`AES256GCM` + in-memory backend: store→retrieve round-trip, missing key, corrupted-ciphertext eviction, repoKey-as-AAD binding, delete, plus backend delegation and config bean selection. Pre-existing credential-flow tests still pass routed through the real store.

---


[OSIS-161]: https://scality.atlassian.net/browse/OSIS-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ