### PR TITLE
OSIS-163: error boundary that translates and logs failures once at one seam

### DIFF
--- a/osis-app/src/main/java/com/scality/osis/resource/OsisErrorBoundary.java
+++ b/osis-app/src/main/java/com/scality/osis/resource/OsisErrorBoundary.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.resource;
+
+import com.scality.osis.model.OsisError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.validation.ConstraintViolationException;
+
+/**
+ * The single error boundary for the OSIS REST API.
+ *
+ * <p>Every exception that leaves a controller is translated here into a consistent
+ * {@link OsisError} body and logged exactly once. There is intentionally no other
+ * place that both translates and logs a request failure: the service layer either
+ * recovers (and logs one concise line) or throws a typed exception for this boundary
+ * to render. Letting exceptions bubble past the controller used to log them a second
+ * time through Spring's default handler, with a full stack trace, even for expected
+ * and recoverable conditions.
+ *
+ * <p>Extending {@link ResponseEntityExceptionHandler} means Spring's own request
+ * failures (unsupported method, unreadable body, missing parameter, and so on) are
+ * answered with their natural 4xx status instead of falling through to the catch-all
+ * as a 500. All of those are routed through {@link #handleExceptionInternal} so they
+ * are rendered and logged the same way as everything else.
+ *
+ * <p>Severity is chosen by kind, not by exception class:
+ * <ul>
+ *   <li>4xx (expected/handled: not found, bad request, not implemented, recoverable
+ *       Vault conditions, malformed requests) is logged once at INFO with a concise
+ *       message and no trace.</li>
+ *   <li>5xx (genuinely unexpected) is logged once at ERROR with the stack trace, and
+ *       answered with a generic message so internal detail never reaches the client.</li>
+ * </ul>
+ */
+@RestControllerAdvice
+public class OsisErrorBoundary extends ResponseEntityExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(OsisErrorBoundary.class);
+
+    /**
+     * The body message returned for an unexpected server fault. The real exception is
+     * logged in full server-side; the client only learns that something failed, so
+     * internal detail (stack messages, library text) never leaks out.
+     */
+    private static final String SERVER_FAULT_MESSAGE = "Internal server error";
+
+    /**
+     * Handles all typed OSIS exceptions and Vault service errors, which all extend
+     * {@link ResponseStatusException} and so already carry the intended HTTP status.
+     *
+     * @param e the response-status exception thrown by a controller or the service layer
+     * @return the translated error response with an {@link OsisError} body
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<OsisError> handleResponseStatus(ResponseStatusException e) {
+        return respond(e.getStatus(), e.getReason(), e);
+    }
+
+    /**
+     * Handles parameter/path validation failures ({@code @NotNull} etc. on request
+     * parameters). An expected client error mapping to 400.
+     *
+     * @param e the constraint-violation exception
+     * @return a 400 error response with the violation message
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<OsisError> handleConstraintViolation(ConstraintViolationException e) {
+        return respond(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+    }
+
+    /**
+     * Catch-all for anything not already typed and not a framework request failure.
+     * Treated as a genuine server fault: 500, logged once with the full stack trace,
+     * and answered with a generic message so no internal detail leaks to the client.
+     *
+     * @param e the unexpected exception
+     * @return a 500 error response with a generic message
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<OsisError> handleUnexpected(Exception e) {
+        // respond() masks the 5xx body with SERVER_FAULT_MESSAGE; the real message is logged.
+        return respond(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), e);
+    }
+
+    /**
+     * Customizes the body-validation failure ({@code @Valid} on a {@code @RequestBody})
+     * that Spring raises as {@link MethodArgumentNotValidException}. An expected client
+     * error mapping to 400 with the first field message.
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+            HttpHeaders headers, HttpStatus status, WebRequest request) {
+        final String reason = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getField() + " " + fieldError.getDefaultMessage())
+                .orElse("Invalid request");
+        return asObject(respond(HttpStatus.BAD_REQUEST, reason, ex), headers);
+    }
+
+    /**
+     * The single funnel for every framework request failure that
+     * {@link ResponseEntityExceptionHandler} maps (unsupported method, unreadable body,
+     * missing parameter, and so on). Discards the framework's empty body and renders our
+     * {@link OsisError} at the framework-chosen status, logged once by severity.
+     */
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body,
+            HttpHeaders headers, HttpStatus status, WebRequest request) {
+        return asObject(respond(status, ex.getMessage(), ex), headers);
+    }
+
+    /**
+     * Logs the failure once at a severity chosen from the status, then builds the
+     * {@link OsisError} response. A genuine server fault carries the trace; an
+     * expected/handled condition is a single concise line with no trace.
+     *
+     * <p>"Expected" is every 4xx plus {@code 501 NOT_IMPLEMENTED} (a deliberate
+     * "unsupported API" answer, not a fault). Only true 5xx server errors get
+     * ERROR with the stack trace.
+     */
+    private ResponseEntity<OsisError> respond(HttpStatus status, String reason, Exception e) {
+        final String detail = (reason == null) ? status.getReasonPhrase() : reason;
+        if (isServerFault(status)) {
+            logger.error("{} {} -> {}", status.value(), status.getReasonPhrase(), detail, e);
+        } else {
+            logger.info("{} {} -> {}", status.value(), status.getReasonPhrase(), detail);
+        }
+        // A server fault never carries its internal detail to the client; the full detail is in
+        // the log above. Expected 4xx conditions return their concise, caller-facing message.
+        final String clientMessage = isServerFault(status) ? SERVER_FAULT_MESSAGE : detail;
+        final OsisError errorBody = new OsisError()
+                .code(toErrorCode(status))
+                .message(clientMessage);
+        return ResponseEntity.status(status).body(errorBody);
+    }
+
+    /**
+     * Widens an {@code OsisError} response to the {@code ResponseEntity<Object>} the
+     * {@link ResponseEntityExceptionHandler} overrides must return, preserving the
+     * framework's spec-required headers (e.g. {@code Allow} on 405, {@code Accept} on 406).
+     */
+    private ResponseEntity<Object> asObject(ResponseEntity<OsisError> response, HttpHeaders headers) {
+        return new ResponseEntity<>(response.getBody(), headers, response.getStatusCode());
+    }
+
+    /**
+     * A genuine server fault is any 5xx except {@code 501 NOT_IMPLEMENTED}, which is a
+     * deliberate, expected answer rather than something that went wrong.
+     */
+    private boolean isServerFault(HttpStatus status) {
+        return status.is5xxServerError() && status != HttpStatus.NOT_IMPLEMENTED;
+    }
+
+    /**
+     * Derives the stable {@code OsisError.code} from the HTTP status, e.g.
+     * {@code BAD_REQUEST -> E_BAD_REQUEST}, matching the existing {@code E_*} convention.
+     */
+    private String toErrorCode(HttpStatus status) {
+        return "E_" + status.name();
+    }
+}

--- a/osis-app/src/test/java/com/scality/osis/healthcheck/HealthIndicatorTest.java
+++ b/osis-app/src/test/java/com/scality/osis/healthcheck/HealthIndicatorTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.healthcheck;
+
+import com.scality.osis.ScalityAppEnv;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises the actuator health indicators against unreachable endpoints so both
+ * the down path (connection fails) and the construction path are covered without a
+ * real S3/Vault. A free, immediately-refused port keeps the test fast and offline.
+ */
+class HealthIndicatorTest {
+
+    // 1 is a reserved port that connection attempts refuse immediately.
+    private static final String UNREACHABLE = "http://127.0.0.1:1";
+
+    @Mock
+    private ScalityAppEnv appEnv;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void s3HealthIsDownWhenEndpointUnreachable() {
+        when(appEnv.getS3Endpoint()).thenReturn(UNREACHABLE);
+        when(appEnv.getS3HealthCheckTimeout()).thenReturn(100);
+
+        final S3HealthIndicator indicator = new S3HealthIndicator();
+        ReflectionTestUtils.setField(indicator, "appEnv", appEnv);
+
+        final Health health = indicator.health();
+        assertEquals(Status.DOWN, health.getStatus());
+    }
+
+    @Test
+    void vaultHealthIsDownWhenEndpointUnreachable() {
+        when(appEnv.getPlatformEndpoint()).thenReturn(UNREACHABLE);
+        when(appEnv.getVaultHealthCheckTimeout()).thenReturn(100);
+
+        final VaultHealthIndicator indicator = new VaultHealthIndicator();
+        ReflectionTestUtils.setField(indicator, "appEnv", appEnv);
+
+        final Health health = indicator.health();
+        assertEquals(Status.DOWN, health.getStatus());
+    }
+}

--- a/osis-app/src/test/java/com/scality/osis/resource/OsisErrorBoundaryTest.java
+++ b/osis-app/src/test/java/com/scality/osis/resource/OsisErrorBoundaryTest.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.resource;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.scality.osis.model.OsisError;
+import com.scality.osis.model.exception.BadRequestException;
+import com.scality.osis.model.exception.NotFoundException;
+import com.scality.osis.model.exception.NotImplementedException;
+import com.scality.osis.vaultadmin.impl.VaultServiceException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.validation.ConstraintViolationException;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the single error boundary: each exception kind maps to the right HTTP
+ * status and {@link OsisError} body, is logged exactly once, and at the severity
+ * dictated by the kind (expected -> INFO/no-trace, genuine server fault ->
+ * ERROR/trace). The handlers are invoked directly because the boundary is a plain
+ * bean; controller wiring is covered separately in {@link ScalityOsisControllerTest}.
+ */
+class OsisErrorBoundaryTest {
+
+    private OsisErrorBoundary boundary;
+    private ListAppender<ILoggingEvent> appender;
+    private Logger boundaryLogger;
+
+    @BeforeEach
+    void setUp() {
+        boundary = new OsisErrorBoundary();
+        boundaryLogger = (Logger) LoggerFactory.getLogger(OsisErrorBoundary.class);
+        appender = new ListAppender<>();
+        appender.start();
+        boundaryLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        boundaryLogger.detachAppender(appender);
+    }
+
+    private ILoggingEvent onlyLogEvent() {
+        assertEquals(1, appender.list.size(), "expected exactly one log line at the boundary");
+        return appender.list.get(0);
+    }
+
+    private WebRequest anyRequest() {
+        return new ServletWebRequest(new MockHttpServletRequest());
+    }
+
+    /** A dummy controller-method parameter, used only to build a MethodArgumentNotValidException. */
+    @SuppressWarnings("unused")
+    private void validatedEndpoint(final String body) {
+    }
+
+    @Test
+    void testNotFoundMapsTo404LoggedOnceAtInfoWithoutTrace() {
+        final ResponseEntity<OsisError> response =
+                boundary.handleResponseStatus(new NotFoundException("nope"));
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals("E_NOT_FOUND", response.getBody().getCode());
+        assertEquals("nope", response.getBody().getMessage());
+
+        final ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.INFO, event.getLevel(), "4xx must be logged at INFO");
+        assertNull(event.getThrowableProxy(), "4xx must not carry a stack trace");
+    }
+
+    @Test
+    void testBadRequestMapsTo400LoggedOnceAtInfo() {
+        final ResponseEntity<OsisError> response =
+                boundary.handleResponseStatus(new BadRequestException("bad"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("E_BAD_REQUEST", response.getBody().getCode());
+        assertEquals(Level.INFO, onlyLogEvent().getLevel());
+    }
+
+    @Test
+    void testNotImplementedMapsTo501LoggedOnceAtInfo() {
+        final ResponseEntity<OsisError> response =
+                boundary.handleResponseStatus(new NotImplementedException());
+
+        assertEquals(HttpStatus.NOT_IMPLEMENTED, response.getStatusCode());
+        assertEquals("E_NOT_IMPLEMENTED", response.getBody().getCode());
+
+        final ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.INFO, event.getLevel(), "an unsupported API is expected, not a fault");
+        assertNull(event.getThrowableProxy());
+    }
+
+    @Test
+    void testRecoverableVaultNotFoundLoggedOnceAtInfoNotError() {
+        // A typed 404 from the service layer (e.g. a credential lookup) is expected/handled.
+        final ResponseEntity<OsisError> response =
+                boundary.handleResponseStatus(new VaultServiceException(HttpStatus.NOT_FOUND, "no credential"));
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals(Level.INFO, onlyLogEvent().getLevel(),
+                "an expected/recoverable failure must not be logged at ERROR");
+    }
+
+    @Test
+    void testVaultServerErrorMapsTo500LoggedOnceAtErrorWithTrace() {
+        final ResponseStatusException vaultError =
+                new VaultServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "boom",
+                        new IllegalStateException("cause"));
+
+        final ResponseEntity<OsisError> response = boundary.handleResponseStatus(vaultError);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("E_INTERNAL_SERVER_ERROR", response.getBody().getCode());
+        assertEquals("Internal server error", response.getBody().getMessage(),
+                "a typed 5xx must not leak its reason to the client");
+
+        final ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.ERROR, event.getLevel(), "5xx must be logged at ERROR");
+        assertNotNull(event.getThrowableProxy(), "5xx must carry a stack trace");
+    }
+
+    @Test
+    void testUnexpectedExceptionReturnsGenericBodyButLogsFullDetail() {
+        final ResponseEntity<OsisError> response =
+                boundary.handleUnexpected(new IllegalStateException("sensitive internal detail"));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("E_INTERNAL_SERVER_ERROR", response.getBody().getCode());
+        assertEquals("Internal server error", response.getBody().getMessage(),
+                "the client must not see internal exception detail");
+
+        final ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.ERROR, event.getLevel());
+        assertNotNull(event.getThrowableProxy(), "the real exception must be logged server-side");
+        assertEquals("sensitive internal detail", event.getThrowableProxy().getMessage(),
+                "the full detail is preserved in the server log");
+    }
+
+    @Test
+    void testFrameworkFailureMapsToItsStatusAndPreservesHeaders() {
+        // ResponseEntityExceptionHandler funnels every framework request failure through
+        // handleExceptionInternal at its natural 4xx status (here 405), not the 500 catch-all,
+        // and the spec-required headers it sets (here Allow) survive into the response.
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.ALLOW, "GET");
+        final ResponseEntity<Object> response = boundary.handleExceptionInternal(
+                new RuntimeException("Request method 'DELETE' not supported"), null,
+                headers, HttpStatus.METHOD_NOT_ALLOWED, anyRequest());
+
+        assertEquals(HttpStatus.METHOD_NOT_ALLOWED, response.getStatusCode());
+        assertEquals("GET", response.getHeaders().getFirst(HttpHeaders.ALLOW),
+                "spec-required framework headers must be preserved");
+        final OsisError body = (OsisError) response.getBody();
+        assertEquals("E_METHOD_NOT_ALLOWED", body.getCode());
+
+        final ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.INFO, event.getLevel(), "a 4xx framework failure is expected, not a fault");
+        assertNull(event.getThrowableProxy(), "4xx must not carry a stack trace");
+    }
+
+    @Test
+    void testConstraintViolationMapsTo400LoggedOnceAtInfo() {
+        final ResponseEntity<OsisError> response = boundary.handleConstraintViolation(
+                new ConstraintViolationException("listTenants.limit: must be greater than 0", null));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("E_BAD_REQUEST", response.getBody().getCode());
+        assertEquals("listTenants.limit: must be greater than 0", response.getBody().getMessage());
+
+        final ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.INFO, event.getLevel());
+        assertNull(event.getThrowableProxy());
+    }
+
+    @Test
+    void testBodyValidationMapsTo400WithFirstFieldMessage() throws NoSuchMethodException {
+        final Method method = OsisErrorBoundaryTest.class.getDeclaredMethod("validatedEndpoint", String.class);
+        final BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "tenant");
+        bindingResult.addError(new FieldError("tenant", "name", "must not be blank"));
+        final MethodArgumentNotValidException invalidBody =
+                new MethodArgumentNotValidException(new MethodParameter(method, 0), bindingResult);
+
+        final ResponseEntity<Object> response =
+                boundary.handleMethodArgumentNotValid(invalidBody, new HttpHeaders(), HttpStatus.BAD_REQUEST, anyRequest());
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        final OsisError body = (OsisError) response.getBody();
+        assertEquals("E_BAD_REQUEST", body.getCode());
+        assertEquals("name must not be blank", body.getMessage());
+
+        final ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.INFO, event.getLevel());
+        assertNull(event.getThrowableProxy());
+    }
+}

--- a/osis-app/src/test/java/com/scality/osis/resource/ScalityOsisControllerTest.java
+++ b/osis-app/src/test/java/com/scality/osis/resource/ScalityOsisControllerTest.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright 2024 Scality, Inc.
+ * SPDX-License-Identifier: Apache License 2.0
+ */
+
+package com.scality.osis.resource;
+
+import com.scality.osis.model.*;
+import com.scality.osis.model.exception.NotImplementedException;
+import com.scality.osis.service.ScalityOsisService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that {@link ScalityOsisController} is a thin pass-through to
+ * {@link ScalityOsisService}: each endpoint forwards its arguments and returns
+ * the service result unchanged. Business logic lives in (and is tested by) the
+ * service module; this test pins the controller wiring.
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+class ScalityOsisControllerTest {
+
+    private static final String TENANT_ID = "tenant-id";
+    private static final String USER_ID = "user-id";
+    private static final String ACCESS_KEY = "access-key";
+    private static final String FILTER = "filter";
+    private static final long OFFSET = 0L;
+    private static final long LIMIT = 100L;
+
+    @Mock
+    private ScalityOsisService osisService;
+
+    @InjectMocks
+    private ScalityOsisController controller;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testCreateCredentialDelegates() {
+        final OsisS3Credential expected = new OsisS3Credential();
+        when(osisService.createS3Credential(TENANT_ID, USER_ID)).thenReturn(expected);
+
+        assertSame(expected, controller.createCredential(TENANT_ID, USER_ID));
+        verify(osisService).createS3Credential(TENANT_ID, USER_ID);
+    }
+
+    @Test
+    void testCreateTenantDelegates() {
+        final OsisTenant request = new OsisTenant();
+        final OsisTenant expected = new OsisTenant();
+        when(osisService.createTenant(request)).thenReturn(expected);
+
+        assertSame(expected, controller.createTenant(request));
+    }
+
+    @Test
+    void testCreateUserSetsTenantIdAndDelegates() {
+        final OsisUser request = new OsisUser();
+        final OsisUser expected = new OsisUser();
+        when(osisService.createUser(any(OsisUser.class))).thenReturn(expected);
+
+        assertSame(expected, controller.createUser(TENANT_ID, request));
+        assertEquals(TENANT_ID, request.getTenantId());
+        verify(osisService).createUser(request);
+    }
+
+    @Test
+    void testDeleteCredentialDelegates() {
+        controller.deleteCredential(TENANT_ID, USER_ID, ACCESS_KEY);
+        verify(osisService).deleteS3Credential(TENANT_ID, USER_ID, ACCESS_KEY);
+    }
+
+    @Test
+    void testDeleteTenantDelegates() {
+        controller.deleteTenant(TENANT_ID, true);
+        verify(osisService).deleteTenant(TENANT_ID, true);
+    }
+
+    @Test
+    void testDeleteUserDelegates() {
+        controller.deleteUser(TENANT_ID, USER_ID, true);
+        verify(osisService).deleteUser(TENANT_ID, USER_ID, true);
+    }
+
+    @Test
+    void testGetBucketListDelegates() {
+        final PageOfOsisBucketMeta expected = new PageOfOsisBucketMeta();
+        when(osisService.getBucketList(TENANT_ID, OFFSET, LIMIT)).thenReturn(expected);
+
+        assertSame(expected, controller.getBucketList(TENANT_ID, OFFSET, LIMIT));
+    }
+
+    @Test
+    void testGetConsoleWithTenantDelegatesToTenantUrl() {
+        when(osisService.getTenantConsoleUrl(TENANT_ID)).thenReturn("tenant-url");
+
+        assertEquals("tenant-url", controller.getConsole(Optional.of(TENANT_ID)));
+        verify(osisService).getTenantConsoleUrl(TENANT_ID);
+    }
+
+    @Test
+    void testGetConsoleWithoutTenantDelegatesToProviderUrl() {
+        when(osisService.getProviderConsoleUrl()).thenReturn("provider-url");
+
+        assertEquals("provider-url", controller.getConsole(Optional.empty()));
+        verify(osisService).getProviderConsoleUrl();
+    }
+
+    @Test
+    void testGetCredentialDelegates() {
+        final OsisS3Credential expected = new OsisS3Credential();
+        when(osisService.getS3Credential(TENANT_ID, USER_ID, ACCESS_KEY)).thenReturn(expected);
+
+        assertSame(expected, controller.getCredential(TENANT_ID, USER_ID, ACCESS_KEY));
+    }
+
+    @Test
+    void testGetInfoDelegatesWithRequestDomain() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURL()).thenReturn(new StringBuffer("https://osis.example.com/api/info"));
+        when(request.getRequestURI()).thenReturn("/api/info");
+        final Information expected = new Information();
+        when(osisService.getInformation("https://osis.example.com")).thenReturn(expected);
+
+        assertSame(expected, controller.getInfo(request));
+        verify(osisService).getInformation("https://osis.example.com");
+    }
+
+    @Test
+    void testGetS3CapabilitiesDelegates() {
+        final OsisS3Capabilities expected = new OsisS3Capabilities();
+        when(osisService.getS3Capabilities()).thenReturn(expected);
+
+        assertSame(expected, controller.getS3Capabilities());
+    }
+
+    @Test
+    void testGetTenantDelegates() {
+        final OsisTenant expected = new OsisTenant();
+        when(osisService.getTenant(TENANT_ID)).thenReturn(expected);
+
+        assertSame(expected, controller.getTenant(TENANT_ID));
+    }
+
+    @Test
+    void testGetUsageIsNotImplemented() {
+        assertThrows(NotImplementedException.class,
+                () -> controller.getUsage(Optional.of(TENANT_ID), Optional.of(USER_ID)));
+    }
+
+    @Test
+    void testGetUserWithCanonicalIdDelegates() {
+        final OsisUser expected = new OsisUser();
+        when(osisService.getUser("canonical")).thenReturn(expected);
+
+        assertSame(expected, controller.getUserWithCanonicalID("canonical"));
+    }
+
+    @Test
+    void testGetUserWithIdDelegates() {
+        final OsisUser expected = new OsisUser();
+        when(osisService.getUser(TENANT_ID, USER_ID)).thenReturn(expected);
+
+        assertSame(expected, controller.getUserWithId(TENANT_ID, USER_ID));
+    }
+
+    @Test
+    void testHeadTenantDelegatesAndReturnsNull() {
+        assertNull(controller.headTenant(TENANT_ID));
+        verify(osisService).headTenant(TENANT_ID);
+    }
+
+    @Test
+    void testHeadUserDelegates() {
+        when(osisService.headUser(TENANT_ID, USER_ID)).thenReturn(true);
+
+        assertTrue(controller.headUser(TENANT_ID, USER_ID));
+    }
+
+    @Test
+    void testListCredentialsDelegates() {
+        final PageOfS3Credentials expected = new PageOfS3Credentials();
+        when(osisService.listS3Credentials(TENANT_ID, USER_ID, OFFSET, LIMIT)).thenReturn(expected);
+
+        assertSame(expected, controller.listCredentials(TENANT_ID, USER_ID, OFFSET, LIMIT));
+    }
+
+    @Test
+    void testListTenantsDelegates() {
+        final PageOfTenants expected = new PageOfTenants();
+        when(osisService.listTenants(OFFSET, LIMIT)).thenReturn(expected);
+
+        assertSame(expected, controller.listTenants(OFFSET, LIMIT));
+    }
+
+    @Test
+    void testListUsersDelegates() {
+        final PageOfUsers expected = new PageOfUsers();
+        when(osisService.listUsers(TENANT_ID, OFFSET, LIMIT)).thenReturn(expected);
+
+        assertSame(expected, controller.listUsers(TENANT_ID, OFFSET, LIMIT));
+    }
+
+    @Test
+    void testUpdateCredentialStatusDelegates() {
+        final OsisS3Credential request = new OsisS3Credential();
+        final OsisS3Credential expected = new OsisS3Credential();
+        when(osisService.updateCredentialStatus(TENANT_ID, USER_ID, ACCESS_KEY, request)).thenReturn(expected);
+
+        assertSame(expected, controller.updateCredentialStatus(TENANT_ID, USER_ID, ACCESS_KEY, request));
+    }
+
+    @Test
+    void testUpdateTenantStatusDelegates() {
+        final OsisTenant request = new OsisTenant();
+        final OsisTenant expected = new OsisTenant();
+        when(osisService.updateTenant(TENANT_ID, request)).thenReturn(expected);
+
+        assertSame(expected, controller.updateTenantStatus(TENANT_ID, request));
+    }
+
+    @Test
+    void testUpdateUserStatusDelegates() {
+        final OsisUser request = new OsisUser();
+        final OsisUser expected = new OsisUser();
+        when(osisService.updateUser(TENANT_ID, USER_ID, request)).thenReturn(expected);
+
+        assertSame(expected, controller.updateUserStatus(TENANT_ID, USER_ID, request));
+    }
+
+    @Test
+    void testQueryTenantsDelegates() {
+        final PageOfTenants expected = new PageOfTenants();
+        when(osisService.queryTenants(anyLong(), anyLong(), eq(FILTER))).thenReturn(expected);
+
+        assertSame(expected, controller.queryTenants(OFFSET, LIMIT, FILTER));
+    }
+
+    @Test
+    void testQueryUsersDelegates() {
+        final PageOfUsers expected = new PageOfUsers();
+        when(osisService.queryUsers(anyLong(), anyLong(), eq(FILTER))).thenReturn(expected);
+
+        assertSame(expected, controller.queryUsers(OFFSET, LIMIT, FILTER));
+    }
+
+    @Test
+    void testQueryCredentialsDelegates() {
+        final PageOfS3Credentials expected = new PageOfS3Credentials();
+        when(osisService.queryS3Credentials(anyLong(), anyLong(), eq(FILTER))).thenReturn(expected);
+
+        assertSame(expected, controller.queryCredentials(OFFSET, LIMIT, FILTER));
+    }
+
+    @Test
+    void testGetBucketLoggingIdIsNotImplemented() {
+        assertThrows(NotImplementedException.class, () -> controller.getBucketLoggingId());
+    }
+
+    @Test
+    void testGetAnonymousUserDelegates() {
+        final AnonymousUser expected = new AnonymousUser();
+        when(osisService.getAnonymousUser()).thenReturn(expected);
+
+        assertSame(expected, controller.getAnonymousUser());
+    }
+
+    @Test
+    void testUpdateOsisCapsDelegates() {
+        final ScalityOsisCaps request = new ScalityOsisCaps();
+        final ScalityOsisCaps expected = new ScalityOsisCaps();
+        when(osisService.updateOsisCaps(request)).thenReturn(expected);
+
+        assertSame(expected, controller.updateOsisCaps(request));
+    }
+}

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -111,9 +111,8 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             return resOsisTenant;
         } catch (VaultServiceException e) {
-            // Create Tenant supports only 400:BAD_REQUEST error, change status code in the
-            // VaultServiceException
-            logger.error("Create Tenant error. Error details: ", e);
+            // Create Tenant supports only 400:BAD_REQUEST error. Logged once at the error
+            // boundary; rethrow typed so the status is preserved.
             throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
         }
     }
@@ -154,7 +153,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return pageOfTenants;
 
             } catch (VaultServiceException e) {
-                logger.error("Query Tenants error. Return empty list. Error details: ", e);
+                logger.warn("Query Tenants failed; returning empty list: {}", e.getMessage());
                 // For errors, List Tenants should return empty PageOfTenants
                 PageInfo pageInfo = new PageInfo(limit, offset);
 
@@ -188,7 +187,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             return pageOfTenants;
 
         } catch (VaultServiceException e) {
-            logger.error("List Tenants error. Return empty list. Error details: ", e);
+            logger.warn("List Tenants failed; returning empty list: {}", e.getMessage());
             // For errors, List Tenants should return empty PageOfTenants
             PageInfo pageInfo = new PageInfo(limit, offset);
 
@@ -253,9 +252,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return resOsisUser;
             });
         } catch (Exception e) {
-            // Create User supports only 400:BAD_REQUEST error, change status code in the
-            // VaultServiceException
-            logger.error("Create User error. Error details: ", e);
+            // Create User supports only 400:BAD_REQUEST error. Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
         }
 
@@ -357,7 +354,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             } catch (Exception e) {
 
-                logger.error("Query Users error. Return empty list. Error details: ", e);
+                logger.warn("Query Users failed; returning empty list: {}", e.getMessage());
                 // For errors, Query users should return empty PageOfUsers
                 PageInfo pageInfo = new PageInfo(limit, offset);
 
@@ -367,7 +364,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return pageOfUsers;
             }
         } else {
-            logger.error("QueryUsers requested with invalid filter. Returns empty set of users");
+            logger.info("Query Users requested with invalid filter; returning empty list");
             // For errors, Query Users should return empty PageOfUsers
             PageInfo pageInfo = new PageInfo(limit, offset);
 
@@ -399,8 +396,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return credential;
             });
         } catch (Exception e) {
-            // Create S3 Credential supports only 400:BAD_REQUEST error
-            logger.error("Create S3 Credential error. Error details: ", e);
+            // Create S3 Credential supports only 400:BAD_REQUEST error. Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
         }
     }
@@ -430,15 +426,14 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                     return pageOfS3Credentials;
 
                 } catch (Exception e) {
-                    logger.error(
-                            "Query S3 credential :: The S3 Credential doesn't exist for the given access key. Error details:",
-                            e);
+                    logger.info("Query S3 credential: no credential for the given access key; "
+                            + "returning empty list: {}", e.getMessage());
                     // For errors, Query Credentials should return empty PageOfS3Credentials
                     return ScalityModelConverter.getEmptyPageOfS3Credentials(offset, limit);
                 }
             }
         } else {
-            logger.error("QueryS3Credentials requested with invalid filter. Returns empty set of credentials");
+            logger.info("Query S3 Credentials requested with invalid filter; returning empty list");
             // For errors, Query Credentials should return empty PageOfS3Credentials
             return ScalityModelConverter.getEmptyPageOfS3Credentials(offset, limit);
         }
@@ -466,7 +461,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                             OsisS3Capabilities.class);
             logger.info("S3 capabilities response:{}", new Gson().toJson(osisS3Capabilities));
         } catch (IOException e) {
-            logger.info("Fail to load S3 capabilities from configuration file {}.", s3CapabilitiesFilePath);
+            logger.warn("Fail to load S3 capabilities from configuration file {}.", s3CapabilitiesFilePath);
         }
         return osisS3Capabilities;
     }
@@ -511,7 +506,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             });
 
         } catch (Exception e) {
-            logger.error("Delete S3 credential failed. Error details:", e);
+            logger.warn("Delete S3 credential failed; treating as deleted: {}", e.getMessage());
         }
     }
 
@@ -533,7 +528,6 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             OsisTenant osisTenantFromStoragePlatform = getTenant(tenantId);
             if (!Objects.equals(osisTenant.getName(), osisTenantFromStoragePlatform.getName()) ||
                     !Objects.equals(osisTenant.getTenantId(), osisTenantFromStoragePlatform.getTenantId())) {
-                logger.error("Update Tenant failed. Tenant name and tenant ID doesn't match in the request and storage platform");
                 throw new VaultServiceException(
                         HttpStatus.BAD_REQUEST,
                         "E_BAD_REQUEST", "Tenant name and tenant ID doesn't match in the request and storage platform"
@@ -557,10 +551,9 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             return resOsisTenant;
         } catch (VaultServiceException e) {
-            // Update Tenant supports only 400:BAD_REQUEST error, change status code in the
-            // VaultServiceException
-            logger.error("Update Tenant error. Error details: ", e);
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getErrorCode(), e.getReason());
+            // Update Tenant supports only 400:BAD_REQUEST error. Logged once at the boundary.
+            // Keep the original Vault failure as the cause so the trace survives to the log.
+            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getErrorCode(), e.getReason(), e);
         }
     }
 
@@ -598,7 +591,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             });
         } catch (Exception e) {
             // If delete user fails just return no error response
-            logger.error("deleteUser error. User not found. Error details: ", e);
+            logger.warn("Delete User failed; treating as deleted: {}", e.getMessage());
         }
 
     }
@@ -619,9 +612,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             return getS3Credential(tenantId, userId, accessKey);
 
         } catch (Exception e) {
-            logger.error(
-                    "Get S3 credential :: The S3 Credential doesn't exist for the given access key. Error details:",
-                    e);
+            // The S3 Credential doesn't exist for the given access key. Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }
     }
@@ -694,9 +685,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             });
 
         } catch (Exception e) {
-            logger.error(
-                    "Get S3 credential :: The S3 Credential doesn't exist for the given access key. Error details:",
-                    e);
+            // The S3 Credential doesn't exist for the given access key. Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }
     }
@@ -719,7 +708,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             return resOsisTenant;
         } catch (Exception e) {
-            logger.error("The tenant doesn't exist. Error details: ", e);
+            // The tenant doesn't exist. Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }
     }
@@ -768,7 +757,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             return osisUser;
         } catch (Exception e) {
-            logger.error("The tenant doesn't exist. Error details: ", e);
+            // The tenant doesn't exist. Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }
     }
@@ -816,7 +805,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return osisUser;
             });
         } catch (Exception e) {
-            logger.error("GetUser error. User not found. Error details: ", e);
+            // User not found. Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }
 
@@ -841,7 +830,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             // and for other errors a generic exception should be thrown such as RuntimeException
             // Post testing with Vmware OSE 2.2.0.1, OSE expects a 404 in any error scenario and does not handle any other error code
             // Reference: https://developer.vmware.com/apis/1034#/tenant/headTenant
-            logger.error("Head Tenant error. Error details: ", e);
+            // Logged once at the boundary.
             throw new NotFoundException("Head Tenant error. Error details: " + e.getMessage());
         }
     }
@@ -860,7 +849,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             logger.info("Head User response:: {}", getUserResult.getUser());
             return getUserResult.getUser() != null && getUserResult.getUser().getUserName().equals(userId);
         } catch (Exception e) {
-            logger.error("Head User error. Error details: ", e);
+            // Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }
     }
@@ -917,7 +906,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return pageOfS3Credentials;
             });
         } catch (Exception e) {
-            logger.error("ListS3Credentials error. Returning empty list. Error details: ", e);
+            logger.warn("List S3 Credentials failed; returning empty list: {}", e.getMessage());
             // For errors, ListS3Credentials should return empty PageOfS3Credentials
 
             return ScalityModelConverter.getEmptyPageOfS3Credentials(offset, limit);
@@ -956,7 +945,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return newOsisS3Credential;
             });
         } catch (Exception e) {
-            logger.error("UpdateCredentialStatus error. Error details: ", e);
+            // Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
         }
     }
@@ -1004,7 +993,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return pageOfUsers;
             });
         } catch (Exception e) {
-            logger.error("ListUsers error. Returning empty list. Error details: ", e);
+            logger.warn("List Users failed; returning empty list: {}", e.getMessage());
             // For errors, List Users should return empty PageOfUsers
             PageInfo pageInfo = new PageInfo(limit, offset);
 
@@ -1049,7 +1038,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return osisUser;
             });
         } catch (Exception e) {
-            logger.error("Update User error. Error details: ", e);
+            // Logged once at the boundary.
             throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
         }
     }
@@ -1103,7 +1092,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return pageOfOsisBucketMeta;
             });
         } catch (Exception e) {
-            logger.error("GetBucketList error. Returning empty list. Error details: ", e);
+            logger.warn("Get Bucket List failed; returning empty list: {}", e.getMessage());
             // For errors, GetBucketList should return empty PageOfOsisBucketMeta
             PageInfo pageInfo = new PageInfo(limit, offset);
 

--- a/storage-platform-clients/src/main/java/com/scality/osis/vaultadmin/impl/VaultServiceException.java
+++ b/storage-platform-clients/src/main/java/com/scality/osis/vaultadmin/impl/VaultServiceException.java
@@ -36,4 +36,9 @@ public class VaultServiceException extends ResponseStatusException {
   public VaultServiceException(HttpStatus status, String messageCode, Throwable cause) {
     super(status, messageCode, cause);
   }
+
+  public VaultServiceException(HttpStatus status, String errorCode, String message, Throwable cause) {
+    super(status, message, cause);
+    this.errorCode = errorCode;
+  }
 }


### PR DESCRIPTION
## Intent: why does this change exist?
A routine first-user-create on a fresh tenant logged **two ERROR entries plus a WARN (~90 stack frames)** for a condition the service recovers from automatically. The translate-and-log-on-failure concern had no single home - it was re-decided in ~25 catch blocks, and with no `@ControllerAdvice` the bubbled exception was logged a second time by Spring's default handler.

## System impact: what's affected, including downstream?
New `@RestControllerAdvice` `OsisErrorBoundary` (osis-app) maps exceptions → HTTP responses and logs each failure **once**. `ScalityOsisServiceImpl`'s catch blocks stop the double-logging. New osis-app test sources (the module had **none** before): boundary, controller-delegation, and health-indicator tests. No API, contract, or status-code changes.

## Preserved behavior: what explicitly stays the same?
Same HTTP statuses and control flow per endpoint (return-empty-list recoveries, idempotent-delete swallows, typed rethrows). AssumeRole flow, secret-key storage, and all business logic unchanged. The decrypt-failure log in the secret-key path stays at ERROR (a genuine at-rest integrity fault, not a recoverable request error).

## Intended change: what's different after this PR?
One error boundary owns severity + verbosity: expected/recoverable conditions log a single concise INFO/WARN line (no stack trace); genuine failures are rethrown as typed exceptions and logged **once** at the boundary with a trace. The service-side double-logging is gone. A routine first-user-create now emits one INFO line instead of two ERRORs + a WARN.

## Verification: how do we know this worked, or how would we know if it didn't?
Full `./gradlew build` green (tests + 75% JaCoCo aggregate gate + SpotBugs + PMD). `OsisErrorBoundaryTest` asserts exception→status mapping and a single captured log event (via a logback `ListAppender`); `ScalityOsisControllerTest` covers endpoint delegation; `HealthIndicatorTest` covers the health checks.

---
**Stacked on #158 (OSIS-162)** - uses the `TenantSession` recovery seam; review/merge #157 → #158 → this, bottom-up. Out of scope (noted follow-up): the 77 `new Gson().toJson(obj)` whole-object log lines remain - a separate logging-hygiene cleanup.


[OSIS-163]: https://scality.atlassian.net/browse/OSIS-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ