### PR TITLE
OSIS-166: preserve Vault server faults (5xx) instead of masking them as 400

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -85,6 +85,20 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
     }
 
     /**
+     * Builds the exception to surface for a failed create/update operation. A genuine Vault server
+     * fault (a {@link VaultServiceException} with a 5xx status) is returned unchanged so the error
+     * boundary logs it once at ERROR with the stack trace. Every other failure is treated as a
+     * client-side rejection and mapped to {@code 400 BAD_REQUEST}, keeping the original as the cause.
+     */
+    private VaultServiceException toResponseException(Exception e) {
+        if (e instanceof VaultServiceException
+                && ((VaultServiceException) e).getStatus().is5xxServerError()) {
+            return (VaultServiceException) e;
+        }
+        return new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+    }
+
+    /**
      * Create a tenant in the platform
      *
      * @param osisTenant Tenant to create in the platform (required)
@@ -111,9 +125,9 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             return resOsisTenant;
         } catch (VaultServiceException e) {
-            // Create Tenant supports only 400:BAD_REQUEST error. Logged once at the error
-            // boundary; rethrow typed so the status is preserved.
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            // A client-side Vault rejection maps to 400; a genuine Vault server fault (5xx) is
+            // preserved so the boundary logs it once at ERROR with the trace.
+            throw toResponseException(e);
         }
     }
 
@@ -252,8 +266,9 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return resOsisUser;
             });
         } catch (Exception e) {
-            // Create User supports only 400:BAD_REQUEST error. Logged once at the boundary.
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            // A client-side Vault rejection maps to 400; a genuine Vault server fault (5xx) is
+            // preserved so the boundary logs it once at ERROR with the trace.
+            throw toResponseException(e);
         }
 
     }
@@ -396,8 +411,9 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return credential;
             });
         } catch (Exception e) {
-            // Create S3 Credential supports only 400:BAD_REQUEST error. Logged once at the boundary.
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            // A client-side Vault rejection maps to 400; a genuine Vault server fault (5xx) is
+            // preserved so the boundary logs it once at ERROR with the trace.
+            throw toResponseException(e);
         }
     }
 
@@ -551,8 +567,12 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             return resOsisTenant;
         } catch (VaultServiceException e) {
-            // Update Tenant supports only 400:BAD_REQUEST error. Logged once at the boundary.
-            // Keep the original Vault failure as the cause so the trace survives to the log.
+            // A genuine Vault server fault (5xx) is preserved so the boundary logs it once at ERROR
+            // with the trace. A client-side rejection maps to 400 (errorCode retained for the
+            // response contract), keeping the original Vault failure as the cause.
+            if (e.getStatus().is5xxServerError()) {
+                throw e;
+            }
             throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getErrorCode(), e.getReason(), e);
         }
     }
@@ -945,8 +965,9 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return newOsisS3Credential;
             });
         } catch (Exception e) {
-            // Logged once at the boundary.
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            // A client-side Vault rejection maps to 400; a genuine Vault server fault (5xx) is
+            // preserved so the boundary logs it once at ERROR with the trace.
+            throw toResponseException(e);
         }
     }
 
@@ -1038,8 +1059,9 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return osisUser;
             });
         } catch (Exception e) {
-            // Logged once at the boundary.
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            // A client-side Vault rejection maps to 400; a genuine Vault server fault (5xx) is
+            // preserved so the boundary logs it once at ERROR with the trace.
+            throw toResponseException(e);
         }
     }
 

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
@@ -74,6 +74,22 @@ class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
     }
 
     @Test
+    void testCreateTenant500PreservesServerFault() {
+
+        when(vaultAdminMock.createAccount(any(CreateAccountRequestDTO.class)))
+                .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
+                    throw new VaultServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "Vault unavailable");
+                });
+
+        final VaultServiceException exception = assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.createTenant(createSampleOsisTenantObj());
+        });
+
+        assertEquals(500, exception.getStatus().value(),
+                "a genuine Vault server fault must not be downgraded to 400");
+    }
+
+    @Test
     void testListTenants() {
         // Setup
         final long offset = 0L;
@@ -317,6 +333,22 @@ class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
 
         assertEquals(400, exception.getStatus().value());
         assertEquals("E_BAD_REQUEST", exception.getErrorCode());
+    }
+
+    @Test
+    void testUpdateTenant500PreservesServerFault() {
+        // A matching request passes the name/ID consistency check and reaches the Vault call.
+        when(vaultAdminMock.updateAccountAttributes(any(UpdateAccountAttributesRequestDTO.class)))
+                .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
+                    throw new VaultServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "Vault unavailable");
+                });
+
+        final VaultServiceException exception = assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.updateTenant(SAMPLE_ID, createSampleOsisTenantObj());
+        });
+
+        assertEquals(500, exception.getStatus().value(),
+                "a genuine Vault server fault must not be downgraded to 400");
     }
 
     @Test


### PR DESCRIPTION
## Intent: why does this change exist?
The six create/update endpoints downgraded every Vault failure to 400, so a genuine Vault server error reached the error boundary as a client 400 and was logged at INFO with no stack trace. That hid intermittent Vault server faults from the logs (full outages are still caught by `VaultHealthIndicator`). Found in review of #159.

## System impact: what's affected, including downstream?
`ScalityOsisServiceImpl`: `createTenant`, `createUser`, `createS3Credential`, `updateCredentialStatus`, `updateUser`, `updateTenant`. OSE now receives a 5xx (instead of 400) from these endpoints when Vault itself returns a server error; a transient Vault failure reads as retryable rather than as a bad request. Stacked on #159.

## Preserved behavior: what explicitly stays the same?
Client-side Vault rejections (4xx) still map to 400 and log at INFO with no trace. `updateTenant` keeps its `E_BAD_REQUEST` errorCode on the 400 path. Non-Vault exceptions in these paths still map to 400 as before. The error boundary, response body shape, and logging seam are unchanged.

## Intended change: what's different after this PR?
A genuine Vault server fault (5xx) propagates with its 5xx status, so the single error boundary logs it once at ERROR with the stack trace. A small `toResponseException` helper centralizes the rule; `updateTenant` keeps it inline to retain its errorCode. The boundary stays the only place that logs, so this keeps the "log once" invariant rather than re-adding a service-layer ERROR log.

## Verification: how do we know this worked, or how would we know if it didn't?
`./gradlew build` green (incl. JaCoCo 75%, SpotBugs, PMD). New tests assert `createTenant` and `updateTenant` surface a Vault 500 as 500, not 400; the existing 400-mapping and consistency tests still pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) · Jira: [OSIS-166](https://scality.atlassian.net/browse/OSIS-166)


[OSIS-166]: https://scality.atlassian.net/browse/OSIS-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ