### PR TITLE
OSIS-165: cap getCredentials access-denied recovery to a single retry

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/tenant/ScalityTenantSession.java
+++ b/osis-core/src/main/java/com/scality/osis/service/tenant/ScalityTenantSession.java
@@ -87,35 +87,52 @@ public class ScalityTenantSession implements TenantSession {
     /**
      * Gets the tenant's temporary assume-role credentials.
      *
-     * <p>On an access-denied response the role is recreated via
-     * {@code setupAssumeRole} and the assume-role is retried.
+     * <p>On the first access-denied response the role is recreated via
+     * {@code setupAssumeRole} and the assume-role is retried exactly once. If the
+     * retry still returns access-denied (a persistent Vault misconfiguration), the
+     * {@link VaultServiceException} is rethrown rather than recursing again, so the
+     * call cannot loop forever and overflow the stack.
      *
      * @param accountID the account id
      * @return the credentials
      */
     private Credentials getCredentials(String accountID) {
-        Credentials credentials;
         try {
-            AssumeRoleRequest assumeRoleRequest = ScalityModelConverter.getAssumeRoleRequestForAccount(accountID,
-                    appEnv.getAssumeRoleName());
-            logger.debug("[Vault] Assume Role request:{}", assumeRoleRequest);
-            credentials = vaultAdmin.getTempAccountCredentials(assumeRoleRequest);
-            logger.debug("[Vault] Assume Role response received with access key:{}, expiration:{}",
-                    credentials.getAccessKeyId(), credentials.getExpiration());
+            return assumeRole(accountID);
         } catch (VaultServiceException e) {
-
-            if (!StringUtils.isNullOrEmpty(e.getErrorCode()) &&
-                    ACCESS_DENIED.equals(e.getErrorCode())) {
-                // if access denied, the osis role is not provisioned yet: set it up and retry
-                logger.debug("Assume role not ready for account {} ({}); recreating the role", accountID, e.getReason());
-                // Call get Account with Account ID to retrieve account name
-                AccountData account = vaultAdmin.getAccount(ScalityModelConverter.toGetAccountRequestWithID(accountID));
-                asyncScalityOsisService.setupAssumeRole(accountID, account.getName());
-                return getCredentials(accountID);
+            if (!isAccessDenied(e)) {
+                throw e;
             }
-            throw e;
+            // access denied: the osis role is not provisioned yet, set it up and retry once
+            logger.debug("Assume role not ready for account {} ({}); recreating the role", accountID, e.getReason());
+            // Call get Account with Account ID to retrieve account name
+            AccountData account = vaultAdmin.getAccount(ScalityModelConverter.toGetAccountRequestWithID(accountID));
+            asyncScalityOsisService.setupAssumeRole(accountID, account.getName());
+
+            try {
+                return assumeRole(accountID);
+            } catch (VaultServiceException retryError) {
+                if (isAccessDenied(retryError)) {
+                    logger.error("Assume role still access-denied for account {} after recreating the role; "
+                            + "giving up to avoid unbounded retries", accountID);
+                }
+                throw retryError;
+            }
         }
+    }
+
+    private Credentials assumeRole(String accountID) {
+        AssumeRoleRequest assumeRoleRequest = ScalityModelConverter.getAssumeRoleRequestForAccount(accountID,
+                appEnv.getAssumeRoleName());
+        logger.debug("[Vault] Assume Role request:{}", assumeRoleRequest);
+        Credentials credentials = vaultAdmin.getTempAccountCredentials(assumeRoleRequest);
+        logger.debug("[Vault] Assume Role response received with access key:{}, expiration:{}",
+                credentials.getAccessKeyId(), credentials.getExpiration());
         return credentials;
+    }
+
+    private boolean isAccessDenied(VaultServiceException e) {
+        return !StringUtils.isNullOrEmpty(e.getErrorCode()) && ACCESS_DENIED.equals(e.getErrorCode());
     }
 
     private void generateAdminPolicy(String tenantId) throws Exception {

--- a/osis-core/src/test/java/com/scality/osis/service/tenant/ScalityTenantSessionTest.java
+++ b/osis-core/src/test/java/com/scality/osis/service/tenant/ScalityTenantSessionTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import java.util.Collections;
 import java.util.Date;
 
+import static com.scality.osis.utils.ScalityConstants.ACCESS_DENIED;
 import static com.scality.osis.utils.ScalityTestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -122,6 +123,24 @@ class ScalityTenantSessionTest {
         // setupAssumeRole called once with the account name resolved via getAccount
         verify(asyncScalityOsisServiceMock).setupAssumeRole(TEST_TENANT_ID, SAMPLE_TENANT_NAME);
         verify(vaultAdminMock, times(2)).getTempAccountCredentials(any(AssumeRoleRequest.class));
+    }
+
+    @Test
+    void stopsRetryingWhenAccessDeniedPersistsAfterRecreatingRole() {
+        when(vaultAdminMock.getTempAccountCredentials(any(AssumeRoleRequest.class)))
+                .thenThrow(new VaultServiceException(HttpStatus.FORBIDDEN, "AccessDenied",
+                        "User: backbeat is not allowed to assume role"));
+
+        // persistent access-denied must surface as a VaultServiceException, not recurse forever
+        final VaultServiceException error = assertThrows(VaultServiceException.class,
+                () -> tenantSessionUnderTest.getIamClient(TEST_TENANT_ID));
+        assertEquals(ACCESS_DENIED, error.getErrorCode());
+
+        // recovery routine invoked at most once
+        verify(asyncScalityOsisServiceMock, times(1)).setupAssumeRole(TEST_TENANT_ID, SAMPLE_TENANT_NAME);
+        // exactly one recovery means one original attempt plus one retry
+        verify(vaultAdminMock, times(2)).getTempAccountCredentials(any(AssumeRoleRequest.class));
+        verifyNoInteractions(iamMock);
     }
 
     @Test


### PR DESCRIPTION
## Intent: why does this change exist?
A persistent Vault ACCESS_DENIED on assume-role made `ScalityTenantSession.getCredentials` recreate the role and then call itself again, with no bound, so a Vault misconfiguration could recurse forever and risk a StackOverflowError. OSIS-162 preserved this behavior as-is; OSIS-165 caps it.

## System impact: what's affected, including downstream?
Only the assume-role credential path used by `getIamClient` / `getS3Client` in `ScalityTenantSession`. Callers that previously could hang/overflow on a misconfigured role now get a fast, clear `VaultServiceException` carrying the original AccessDenied error code.

## Preserved behavior: what explicitly stays the same?
The happy path is unchanged: a first-time AccessDenied still triggers `setupAssumeRole` (resolving the account name via `getAccount`) followed by a successful retry. Non-AccessDenied Vault errors are still rethrown immediately without any recovery.

## Intended change: what's different after this PR?
The unbounded self-recursion is replaced by a one-shot retry: recover once, retry once, and if AccessDenied persists rethrow the existing `VaultServiceException` instead of recursing again. The retry/recovery routine (`setupAssumeRole`) now runs at most once.

## Verification: how do we know this worked, or how would we know if it didn't?
Added `stopsRetryingWhenAccessDeniedPersistsAfterRecreatingRole` which feeds a persistent AccessDenied and asserts a thrown `VaultServiceException`, `setupAssumeRole` invoked exactly once, and exactly two assume-role attempts (no infinite loop). Ran `:osis-core:test` (all 12 ScalityTenantSessionTest cases pass) and `jacocoTestCoverageVerification` (passes, stays >=75%).
