### PR TITLE
OSIS-155: pin headTenant pre-create 404 to INFO, no stack trace

### DIFF
--- a/osis-app/src/test/java/com/scality/osis/resource/OsisErrorBoundaryTest.java
+++ b/osis-app/src/test/java/com/scality/osis/resource/OsisErrorBoundaryTest.java
@@ -90,27 +90,6 @@ class OsisErrorBoundaryTest {
         assertNull(event.getThrowableProxy(), "4xx must not carry a stack trace");
     }
 
-    /**
-     * OSIS-155: the headTenant existence check during tenant activation throws a
-     * NotFoundException when the account does not exist yet. That expected 404 must be
-     * logged once at INFO with no stack trace, so activation no longer prints a misleading
-     * "invalid account ID" error even though the create that follows succeeds.
-     */
-    @Test
-    void testHeadTenantPreCreateNotFoundLoggedOnceAtInfoWithoutTrace() {
-        final ResponseEntity<OsisError> response = boundary.handleResponseStatus(
-                new NotFoundException("Head Tenant error. Error details: The account does not exist"));
-
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertEquals("E_NOT_FOUND", response.getBody().getCode());
-
-        final ILoggingEvent event = onlyLogEvent();
-        assertEquals(Level.INFO, event.getLevel(),
-                "the expected pre-create 404 must be logged at INFO, not ERROR");
-        assertNull(event.getThrowableProxy(),
-                "the expected pre-create 404 must not carry a stack trace");
-    }
-
     @Test
     void testBadRequestMapsTo400LoggedOnceAtInfo() {
         final ResponseEntity<OsisError> response =

--- a/osis-app/src/test/java/com/scality/osis/resource/OsisErrorBoundaryTest.java
+++ b/osis-app/src/test/java/com/scality/osis/resource/OsisErrorBoundaryTest.java
@@ -90,6 +90,27 @@ class OsisErrorBoundaryTest {
         assertNull(event.getThrowableProxy(), "4xx must not carry a stack trace");
     }
 
+    /**
+     * OSIS-155: the headTenant existence check during tenant activation throws a
+     * NotFoundException when the account does not exist yet. That expected 404 must be
+     * logged once at INFO with no stack trace, so activation no longer prints a misleading
+     * "invalid account ID" error even though the create that follows succeeds.
+     */
+    @Test
+    void testHeadTenantPreCreateNotFoundLoggedOnceAtInfoWithoutTrace() {
+        final ResponseEntity<OsisError> response = boundary.handleResponseStatus(
+                new NotFoundException("Head Tenant error. Error details: The account does not exist"));
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals("E_NOT_FOUND", response.getBody().getCode());
+
+        final ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.INFO, event.getLevel(),
+                "the expected pre-create 404 must be logged at INFO, not ERROR");
+        assertNull(event.getThrowableProxy(),
+                "the expected pre-create 404 must not carry a stack trace");
+    }
+
     @Test
     void testBadRequestMapsTo400LoggedOnceAtInfo() {
         final ResponseEntity<OsisError> response =

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
@@ -1,5 +1,9 @@
 package com.scality.osis.service.impl;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.scality.osis.model.OsisTenant;
 import com.scality.osis.model.PageOfTenants;
 import com.scality.osis.model.exception.BadRequestException;
@@ -8,6 +12,7 @@ import com.scality.osis.vaultadmin.impl.VaultServiceException;
 import com.scality.vaultclient.dto.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import com.scality.osis.model.exception.NotFoundException;
 
@@ -398,5 +403,43 @@ class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
         assertThrows(NotFoundException.class, () -> {
             scalityOsisServiceUnderTest.headTenant("bad_tenant_id");
         });
+    }
+
+    /**
+     * OSIS-155: during tenant activation OSE does a headTenant existence check before the
+     * account exists, so the platform answers with a 404 and OSIS rethrows NotFoundException.
+     * That is the expected pre-create path: the service layer must not log it as an error
+     * nor dump a stack trace (the boundary logs the 404 once at INFO). This pins that the
+     * misleading "invalid account ID" stack trace stays gone after OSIS-163.
+     */
+    @Test
+    void testHeadTenantPreCreateNotFoundIsNotLoggedAsError() {
+        // Setup: account does not exist yet, platform returns a 404
+        when(vaultAdminMock.getAccount(any(GetAccountRequestDTO.class)))
+                .thenAnswer((Answer<AccountData>) invocation -> {
+                    throw new VaultServiceException(HttpStatus.NOT_FOUND, "The account does not exist");
+                });
+
+        final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
+        final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        serviceLogger.addAppender(appender);
+
+        try {
+            // Contract: still a 404 for the caller
+            assertThrows(NotFoundException.class,
+                    () -> scalityOsisServiceUnderTest.headTenant(SAMPLE_TENANT_ID));
+
+            // The expected pre-create 404 must not be logged at ERROR or WARN by the service,
+            // and must not carry a stack trace.
+            assertTrue(appender.list.stream().noneMatch(e -> e.getLevel() == Level.ERROR),
+                    "the expected pre-create 404 must not be logged at ERROR");
+            assertTrue(appender.list.stream().noneMatch(e -> e.getLevel() == Level.WARN),
+                    "the expected pre-create 404 must not be logged at WARN");
+            assertTrue(appender.list.stream().allMatch(e -> e.getThrowableProxy() == null),
+                    "the expected pre-create 404 must not dump a stack trace");
+        } finally {
+            serviceLogger.detachAppender(appender);
+        }
     }
 }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
@@ -406,11 +406,11 @@ class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
     }
 
     /**
-     * OSIS-155: during tenant activation OSE does a headTenant existence check before the
-     * account exists, so the platform answers with a 404 and OSIS rethrows NotFoundException.
-     * That is the expected pre-create path: the service layer must not log it as an error
-     * nor dump a stack trace (the boundary logs the 404 once at INFO). This pins that the
-     * misleading "invalid account ID" stack trace stays gone after OSIS-163.
+     * During tenant activation OSE does a headTenant existence check before the account
+     * exists, so the platform answers with a 404 and OSIS rethrows NotFoundException. That is
+     * the expected pre-create path: the service layer must not log it as an error nor dump a
+     * stack trace (the error boundary logs the 404 once at INFO). This pins that the misleading
+     * "invalid account ID" stack trace stays gone.
      */
     @Test
     void testHeadTenantPreCreateNotFoundIsNotLoggedAsError() {


### PR DESCRIPTION
## Intent: why does this change exist?

During tenant activation OSE calls headTenant before the account exists, so the platform answers 404 and OSIS used to log a misleading "invalid account ID" error with a full stack trace even though the create that follows succeeds. The error-boundary work already fixed the behavior; this pins it so it cannot regress.

## System impact: what's affected, including downstream?

Test-only change: osis-core adds a regression test; osis-app drops a redundant near-duplicate test. No production code is touched, so no runtime behavior and no downstream OSE or Vault interaction changes.

## Preserved behavior: what explicitly stays the same?

headTenant still returns a 404 (NotFoundException) for the pre-create case, and the error boundary still translates and logs every 4xx exactly once at INFO. The activation flow is unchanged.

## Intended change: what's different after this PR?

A service-layer regression test (Logback ListAppender) asserting the pre-create 404 is never logged at ERROR or WARN and carries no stack trace. A near-duplicate boundary test was dropped per review, since it exercised the same respond() path as the existing testNotFoundMapsTo404LoggedOnceAtInfoWithoutTrace.

## Verification: how do we know this worked, or how would we know if it didn't?

Ran `./gradlew :osis-core:test :osis-app:test jacocoTestCoverageVerification`: all tests pass and coverage stays above the 75% gate. The new test would fail if anything reintroduced an ERROR-level or stack-trace log for the expected pre-create 404. The underlying behavior was already fixed by the error-boundary change, so no further production change is needed beyond this regression test.
