### PR TITLE
OSIS-156: log empty bucket list at DEBUG, not as a failure

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -27,6 +27,7 @@ import com.scality.osis.utapiclient.dto.ListMetricsRequestDTO;
 import com.scality.osis.utapiclient.dto.MetricsData;
 import com.scality.osis.utapiclient.services.UtapiServiceClient;
 import com.scality.osis.utils.ScalityModelConverter;
+import com.scality.osis.s3.impl.S3ServiceException;
 import com.scality.osis.utils.ScalityUtils;
 import com.scality.osis.vaultadmin.VaultAdmin;
 import com.scality.osis.vaultadmin.impl.VaultServiceException;
@@ -1092,11 +1093,18 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return pageOfOsisBucketMeta;
             });
         } catch (Exception e) {
-            // A tenant with no buckets is an expected, recoverable condition: the platform
-            // answers with a 404/error and OSIS returns an empty list. Log it at DEBUG with a
-            // concise message and no stack trace so the normal "no buckets yet" case does not
-            // read as a failure. A genuine fault still surfaces through the returned empty page.
-            logger.debug("Get Bucket List returned no buckets; returning empty list: {}", e.getMessage());
+            if (e instanceof S3ServiceException
+                    && ((S3ServiceException) e).getStatus() == HttpStatus.NOT_FOUND) {
+                // A tenant with no buckets is an expected, recoverable condition: the platform
+                // answers with a 404 and OSIS returns an empty list. Log it at DEBUG with a
+                // concise message and no stack trace so the normal "no buckets yet" case does
+                // not read as a failure.
+                logger.debug("Get Bucket List returned no buckets; returning empty list: {}", e.getMessage());
+            } else {
+                // A genuine fault (Vault, S3, network, or auth) stays visible to operators at
+                // WARN, even though the OSE contract still requires returning an empty page here.
+                logger.warn("Get Bucket List failed; returning empty list: {}", e.getMessage());
+            }
             // For errors, GetBucketList should return empty PageOfOsisBucketMeta
             PageInfo pageInfo = new PageInfo(limit, offset);
 

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -1092,7 +1092,11 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return pageOfOsisBucketMeta;
             });
         } catch (Exception e) {
-            logger.warn("Get Bucket List failed; returning empty list: {}", e.getMessage());
+            // A tenant with no buckets is an expected, recoverable condition: the platform
+            // answers with a 404/error and OSIS returns an empty list. Log it at DEBUG with a
+            // concise message and no stack trace so the normal "no buckets yet" case does not
+            // read as a failure. A genuine fault still surfaces through the returned empty page.
+            logger.debug("Get Bucket List returned no buckets; returning empty list: {}", e.getMessage());
             // For errors, GetBucketList should return empty PageOfOsisBucketMeta
             PageInfo pageInfo = new PageInfo(limit, offset);
 

--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -10,6 +10,7 @@ import com.amazonaws.Response;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.model.*;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.Bucket;
 import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,7 +28,6 @@ import com.scality.osis.utapiclient.dto.ListMetricsRequestDTO;
 import com.scality.osis.utapiclient.dto.MetricsData;
 import com.scality.osis.utapiclient.services.UtapiServiceClient;
 import com.scality.osis.utils.ScalityModelConverter;
-import com.scality.osis.s3.impl.S3ServiceException;
 import com.scality.osis.utils.ScalityUtils;
 import com.scality.osis.vaultadmin.VaultAdmin;
 import com.scality.osis.vaultadmin.impl.VaultServiceException;
@@ -1093,8 +1093,8 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 return pageOfOsisBucketMeta;
             });
         } catch (Exception e) {
-            if (e instanceof S3ServiceException
-                    && ((S3ServiceException) e).getStatus() == HttpStatus.NOT_FOUND) {
+            if (e instanceof AmazonS3Exception
+                    && ((AmazonS3Exception) e).getStatusCode() == HttpStatus.NOT_FOUND.value()) {
                 // A tenant with no buckets is an expected, recoverable condition: the platform
                 // answers with a 404 and OSIS returns an empty list. Log it at DEBUG with a
                 // concise message and no stack trace so the normal "no buckets yet" case does

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -6,11 +6,11 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.amazonaws.Response;
 import com.amazonaws.services.identitymanagement.model.*;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.Bucket;
 import com.amazonaws.services.s3.model.Owner;
 import com.scality.osis.model.*;
 import com.scality.osis.model.exception.NotImplementedException;
-import com.scality.osis.s3.impl.S3ServiceException;
 import com.scality.osis.utapi.impl.UtapiServiceException;
 import com.scality.osis.utapiclient.dto.ListMetricsRequestDTO;
 import com.scality.osis.utapiclient.dto.MetricsData;
@@ -166,8 +166,10 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         final long limit = 1000L;
         when(s3ClientMock.listBuckets())
                 .thenAnswer((Answer<List<Bucket>>) invocation -> {
-                    throw new S3ServiceException(HttpStatus.BAD_REQUEST,
+                    final AmazonS3Exception ex = new AmazonS3Exception(
                             "Requested offset is outside the total available items");
+                    ex.setStatusCode(HttpStatus.BAD_REQUEST.value());
+                    throw ex;
                 });
 
         final PageOfOsisBucketMeta response = scalityOsisServiceUnderTest.getBucketList(SAMPLE_TENANT_ID, offset, limit);
@@ -191,7 +193,9 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         final long limit = 1000L;
         when(s3ClientMock.listBuckets())
                 .thenAnswer((Answer<List<Bucket>>) invocation -> {
-                    throw new S3ServiceException(HttpStatus.NOT_FOUND, "The specified bucket does not exist");
+                    final AmazonS3Exception ex = new AmazonS3Exception("The specified bucket does not exist");
+                    ex.setStatusCode(HttpStatus.NOT_FOUND.value());
+                    throw ex;
                 });
 
         final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
@@ -244,7 +248,9 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         final long limit = 1000L;
         when(s3ClientMock.listBuckets())
                 .thenAnswer((Answer<List<Bucket>>) invocation -> {
-                    throw new S3ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "storage platform unavailable");
+                    final AmazonS3Exception ex = new AmazonS3Exception("storage platform unavailable");
+                    ex.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                    throw ex;
                 });
 
         final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -1,5 +1,9 @@
 package com.scality.osis.service.impl;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.amazonaws.Response;
 import com.amazonaws.services.identitymanagement.model.*;
 import com.amazonaws.services.s3.model.Bucket;
@@ -17,6 +21,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
 import java.util.ArrayList;
@@ -172,6 +177,59 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
         assertEquals(0L, response.getItems().size());
+    }
+
+    /**
+     * OSIS-156: a tenant that legitimately has no buckets is an expected, recoverable
+     * condition. The empty-list contract must hold and the recovery must not be logged as
+     * an error or warning, nor dump a stack trace, so operators do not chase a non-failure.
+     */
+    @Test
+    void testGetBucketListEmptyLogsAtDebugWithoutErrorOrTrace() {
+        // Setup: tenant with no buckets surfaces as a 404 from the storage platform
+        final long offset = 0L;
+        final long limit = 1000L;
+        when(s3ClientMock.listBuckets())
+                .thenAnswer((Answer<List<Bucket>>) invocation -> {
+                    throw new S3ServiceException(HttpStatus.NOT_FOUND, "The specified bucket does not exist");
+                });
+
+        final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
+        final Level originalLevel = serviceLogger.getLevel();
+        // Capture DEBUG so we can assert the expected case is logged there, not at WARN/ERROR.
+        serviceLogger.setLevel(Level.DEBUG);
+        final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        serviceLogger.addAppender(appender);
+
+        try {
+            // Run: empty-list contract must be preserved
+            final PageOfOsisBucketMeta response =
+                    scalityOsisServiceUnderTest.getBucketList(SAMPLE_TENANT_ID, offset, limit);
+
+            assertEquals(0L, response.getPageInfo().getTotal());
+            assertEquals(offset, response.getPageInfo().getOffset());
+            assertEquals(limit, response.getPageInfo().getLimit());
+            assertEquals(0L, response.getItems().size());
+
+            // The expected "no buckets" case must never be logged at ERROR or WARN, and must
+            // not carry a stack trace.
+            assertTrue(appender.list.stream().noneMatch(e -> e.getLevel() == Level.ERROR),
+                    "the expected empty-bucket case must not be logged at ERROR");
+            assertTrue(appender.list.stream().noneMatch(e -> e.getLevel() == Level.WARN),
+                    "the expected empty-bucket case must not be logged at WARN");
+            assertTrue(appender.list.stream().allMatch(e -> e.getThrowableProxy() == null),
+                    "the expected empty-bucket case must not dump a stack trace");
+
+            // The recovery line is emitted, at DEBUG, with the concise message.
+            assertTrue(appender.list.stream()
+                            .anyMatch(e -> e.getLevel() == Level.DEBUG
+                                    && e.getFormattedMessage().contains("returning empty list")),
+                    "the empty-bucket recovery should be logged once at DEBUG");
+        } finally {
+            serviceLogger.detachAppender(appender);
+            serviceLogger.setLevel(originalLevel);
+        }
     }
 
 

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -232,6 +232,49 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         }
     }
 
+    /**
+     * OSIS-156 (follow-up): only the expected empty-bucket 404 is quieted to DEBUG. A genuine
+     * fault (here a 500 from the storage platform) must stay visible at WARN so operators are not
+     * blind to real failures, while the empty-page contract is still honored.
+     */
+    @Test
+    void testGetBucketListGenuineFaultLogsAtWarn() {
+        // Setup: a non-404 fault from the storage platform (genuine failure, not "no buckets")
+        final long offset = 0L;
+        final long limit = 1000L;
+        when(s3ClientMock.listBuckets())
+                .thenAnswer((Answer<List<Bucket>>) invocation -> {
+                    throw new S3ServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "storage platform unavailable");
+                });
+
+        final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
+        final Level originalLevel = serviceLogger.getLevel();
+        serviceLogger.setLevel(Level.DEBUG);
+        final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        serviceLogger.addAppender(appender);
+
+        try {
+            // Contract: still an empty page for the caller
+            final PageOfOsisBucketMeta response =
+                    scalityOsisServiceUnderTest.getBucketList(SAMPLE_TENANT_ID, offset, limit);
+            assertEquals(0L, response.getItems().size());
+
+            // A genuine (non-404) fault must surface at WARN, not be hidden at DEBUG.
+            assertTrue(appender.list.stream()
+                            .anyMatch(e -> e.getLevel() == Level.WARN
+                                    && e.getFormattedMessage().contains("failed")),
+                    "a genuine bucket-list fault must be logged at WARN");
+            assertTrue(appender.list.stream()
+                            .noneMatch(e -> e.getLevel() == Level.DEBUG
+                                    && e.getFormattedMessage().contains("no buckets")),
+                    "a genuine fault must not be misreported as the expected no-buckets case");
+        } finally {
+            serviceLogger.detachAppender(appender);
+            serviceLogger.setLevel(originalLevel);
+        }
+    }
+
 
     // test to check if getUsage API throws an error not implemented
     // this will be removed as a part of S3C-8266

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -180,9 +180,9 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
     }
 
     /**
-     * OSIS-156: a tenant that legitimately has no buckets is an expected, recoverable
-     * condition. The empty-list contract must hold and the recovery must not be logged as
-     * an error or warning, nor dump a stack trace, so operators do not chase a non-failure.
+     * A tenant that legitimately has no buckets is an expected, recoverable condition. The
+     * empty-list contract must hold and the recovery must not be logged as an error or
+     * warning, nor dump a stack trace, so operators do not chase a non-failure.
      */
     @Test
     void testGetBucketListEmptyLogsAtDebugWithoutErrorOrTrace() {
@@ -233,9 +233,9 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
     }
 
     /**
-     * OSIS-156 (follow-up): only the expected empty-bucket 404 is quieted to DEBUG. A genuine
-     * fault (here a 500 from the storage platform) must stay visible at WARN so operators are not
-     * blind to real failures, while the empty-page contract is still honored.
+     * Only the expected empty-bucket 404 is quieted to DEBUG. A genuine fault (here a 500 from
+     * the storage platform) must stay visible at WARN so operators are not blind to real
+     * failures, while the empty-page contract is still honored.
      */
     @Test
     void testGetBucketListGenuineFaultLogsAtWarn() {


### PR DESCRIPTION
## Intent: why does this change exist?

When a tenant legitimately has no buckets, the platform answers with a 404/error and OSIS recovers to an empty list. That expected case was still logged as a failure (WARN after OSIS-163, ERROR with a full stack before it), which reads as a problem to operators when nothing is wrong.

## System impact: what's affected, including downstream?

One catch block in getBucketList in osis-core. Only the log level and message change; the returned response and HTTP behavior are identical, so OSE sees no difference.

## Preserved behavior: what explicitly stays the same?

getBucketList still returns an empty PageOfOsisBucketMeta with the same pageInfo on the recovery path. The happy path is untouched. A genuine fault still surfaces through the returned empty page exactly as before.

## Intended change: what's different after this PR?

The empty-bucket recovery is logged at DEBUG with a concise message instead of WARN, and continues to carry no stack trace. Adds a ListAppender regression test asserting the empty case returns an empty page and is never logged at ERROR or WARN nor dumps a stack.

## Verification: how do we know this worked, or how would we know if it didn't?

Ran `./gradlew :osis-core:test jacocoTestCoverageVerification`: all tests pass and coverage stays above the 75% gate. The new test fails if the recovery log returns to WARN/ERROR or starts carrying a stack trace.
