### PR TITLE
OSIS-167: contract test that OSIS keeps deactivated S3 credentials in the listing

### DIFF
--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -681,7 +681,7 @@ class ScalityModelConverterTest {
         assertEquals(2, pageOfS3Credentials.getItems().size());
 
         final Map<String, Boolean> activeByKey = new HashMap<>();
-        for (OsisS3Credential cred : pageOfS3Credentials.getItems()) {
+        for (final OsisS3Credential cred : pageOfS3Credentials.getItems()) {
             activeByKey.put(cred.getAccessKey(), cred.getActive());
         }
         assertTrue(activeByKey.containsKey(TEST_ACCESS_KEY_2),

--- a/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
+++ b/osis-core/src/test/java/com/scality/osis/utils/ScalityModelConverterTest.java
@@ -641,6 +641,57 @@ class ScalityModelConverterTest {
     }
 
     @Test
+    void testToPageOfS3CredentialsKeepsInactiveCredential() {
+        // OSIS must keep deactivated (Inactive) access keys in the credential listing as
+        // active=false, never filter them out. Verified live against an OSE 3.1 / VCD lab
+        // (OSIS returns the inactive key in both GET and LIST); this locks the mapping so a
+        // future change cannot start hiding inactive keys on the OSIS side.
+        final AccessKeyMetadata activeKey = new AccessKeyMetadata()
+                .withAccessKeyId(TEST_ACCESS_KEY)
+                .withCreateDate(new Date())
+                .withStatus(StatusType.Active)
+                .withUserName(TEST_USER_ID);
+        final AccessKeyMetadata inactiveKey = new AccessKeyMetadata()
+                .withAccessKeyId(TEST_ACCESS_KEY_2)
+                .withCreateDate(new Date())
+                .withStatus(StatusType.Inactive)
+                .withUserName(TEST_USER_ID);
+
+        final List<AccessKeyMetadata> accessKeyMetadataList = new ArrayList<>();
+        accessKeyMetadataList.add(activeKey);
+        accessKeyMetadataList.add(inactiveKey);
+
+        final ListAccessKeysResult listAccessKeysResult = new ListAccessKeysResult()
+                .withAccessKeyMetadata(accessKeyMetadataList);
+
+        final Map<String, String> secretKeyMap = new HashMap<>();
+        secretKeyMap.put(TEST_ACCESS_KEY, TEST_SECRET_KEY);
+
+        final OsisTenant osisTenant = new OsisTenant();
+        osisTenant.tenantId(SAMPLE_TENANT_ID);
+        osisTenant.name(SAMPLE_TENANT_NAME);
+        osisTenant.cdTenantIds(SAMPLE_CD_TENANT_IDS);
+        osisTenant.active(true);
+
+        // Run the test
+        final PageOfS3Credentials pageOfS3Credentials = ScalityModelConverter
+                .toPageOfS3Credentials(listAccessKeysResult, 0, 1000, osisTenant, secretKeyMap);
+
+        // Verify: both keys are returned (the inactive one is not dropped)
+        assertEquals(2, pageOfS3Credentials.getItems().size());
+
+        final Map<String, Boolean> activeByKey = new HashMap<>();
+        for (OsisS3Credential cred : pageOfS3Credentials.getItems()) {
+            activeByKey.put(cred.getAccessKey(), cred.getActive());
+        }
+        assertTrue(activeByKey.containsKey(TEST_ACCESS_KEY_2),
+                "deactivated key must still appear in the listing");
+        assertEquals(Boolean.TRUE, activeByKey.get(TEST_ACCESS_KEY));
+        assertEquals(Boolean.FALSE, activeByKey.get(TEST_ACCESS_KEY_2),
+                "deactivated key must be active=false, not hidden");
+    }
+
+    @Test
     void testToPageOfS3CredentialsNotAvailableKey() {
         // Setup
 


### PR DESCRIPTION
## Intent: why does this change exist?
Lock the OSIS behavior that S3C-11267 depends on. S3C-11267 reports deactivated S3 keys vanishing from the VCD UI; this regression test proves and pins that OSIS keeps deactivated keys (active=false) in its listing, so the defect is provably downstream of OSIS.

## System impact: what's affected, including downstream?
Test-only. One new unit test in ScalityModelConverterTest. No production code, no runtime or contract behavior change.

## Preserved behavior: what explicitly stays the same?
Everything. The listing already returns inactive keys (ScalityModelConverter.toPageOfS3Credentials maps every AccessKeyMetadata with no status filter); this only guards it.

## Intended change: what's different after this PR?
A new test, testToPageOfS3CredentialsKeepsInactiveCredential, that fails if a future change starts filtering inactive keys out of the credential listing.

## Verification: how do we know this worked, or how would we know if it didn't?
./gradlew :osis-core:test :osis-core:jacocoTestCoverageVerification is green (coverage gate 75% holds). Also reproduced live on the OSE 3.1.0.3 / VCD 10.5.1 lab: after deactivating a key via OSIS, both the single GET and the user credential LIST still return it with active=false.
