### PR TITLE
OSIS-155: do not log the expected headTenant pre-create 404 as an error

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -907,7 +907,8 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             // and for other errors a generic exception should be thrown such as RuntimeException
             // Post testing with Vmware OSE 2.2.0.1, OSE expects a 404 in any error scenario and does not handle any other error code
             // Reference: https://developer.vmware.com/apis/1034#/tenant/headTenant
-            logger.error("Head Tenant error. Error details: ", e);
+            // OSE probes headTenant before the account exists during tenant activation, so this expected
+            // pre-create 404 is not logged as an error here; the 404 is still rethrown for OSE compatibility.
             throw new NotFoundException("Head Tenant error. Error details: " + e.getMessage());
         }
     }

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
@@ -1,5 +1,9 @@
 package com.scality.osis.service.impl;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.scality.osis.model.OsisTenant;
 import com.scality.osis.model.PageOfTenants;
 import com.scality.osis.model.exception.BadRequestException;
@@ -8,6 +12,7 @@ import com.scality.osis.vaultadmin.impl.VaultServiceException;
 import com.scality.vaultclient.dto.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import com.scality.osis.model.exception.NotFoundException;
 
@@ -398,5 +403,42 @@ class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
         assertThrows(NotFoundException.class, () -> {
             scalityOsisServiceUnderTest.headTenant("bad_tenant_id");
         });
+    }
+
+    /**
+     * During tenant activation OSE does a headTenant existence check before the account
+     * exists, so the platform answers with a 404 and OSIS rethrows NotFoundException. That is
+     * the expected pre-create path: the service must not log it as an error nor dump a stack
+     * trace. This pins that the misleading "invalid account ID" stack trace stays gone.
+     */
+    @Test
+    void testHeadTenantPreCreateNotFoundIsNotLoggedAsError() {
+        // Setup: account does not exist yet, platform returns a 404
+        when(vaultAdminMock.getAccount(any(GetAccountRequestDTO.class)))
+                .thenAnswer((Answer<AccountData>) invocation -> {
+                    throw new VaultServiceException(HttpStatus.NOT_FOUND, "The account does not exist");
+                });
+
+        final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
+        final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        serviceLogger.addAppender(appender);
+
+        try {
+            // Contract: still a 404 for the caller
+            assertThrows(NotFoundException.class,
+                    () -> scalityOsisServiceUnderTest.headTenant(SAMPLE_TENANT_ID));
+
+            // The expected pre-create 404 must not be logged at ERROR or WARN by the service,
+            // and must not carry a stack trace.
+            assertTrue(appender.list.stream().noneMatch(e -> e.getLevel() == Level.ERROR),
+                    "the expected pre-create 404 must not be logged at ERROR");
+            assertTrue(appender.list.stream().noneMatch(e -> e.getLevel() == Level.WARN),
+                    "the expected pre-create 404 must not be logged at WARN");
+            assertTrue(appender.list.stream().allMatch(e -> e.getThrowableProxy() == null),
+                    "the expected pre-create 404 must not dump a stack trace");
+        } finally {
+            serviceLogger.detachAppender(appender);
+        }
     }
 }


### PR DESCRIPTION
## Intent: why does this change exist?
During tenant activation OSE probes headTenant before the account exists, so the platform answers 404 and OSIS rethrows NotFoundException. The service logged that expected pre-create case at ERROR with a full stack trace, which reads as a fault during normal activation.

## System impact: what's affected, including downstream?
Service-layer logging only, inside headTenant. No change to the HTTP response, the 404 contract, or any OSE/Vault interaction.

## Preserved behavior: what explicitly stays the same?
headTenant still returns a 404 (NotFoundException) in every error scenario, as OSE requires. Only the spurious ERROR log line is removed.

## Intended change: what's different after this PR?
The expected pre-create 404 is no longer logged as an error with a stack trace. A regression test pins that the service emits no ERROR or WARN and no stack trace for that path while still throwing NotFoundException.

## Verification: how do we know this worked, or how would we know if it didn't?
Ran the full osis-core test module including the 75% JaCoCo gate: green. The new test fails if anything reintroduces an ERROR or stack-trace log for the expected pre-create 404.
