### PR TITLE
OSIS-156: log empty bucket list at DEBUG, classify on AmazonS3Exception 404

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -1216,7 +1216,19 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 }
             }
 
-            logger.error("GetBucketList error. Returning empty list. Error details: ", e);
+            if (e instanceof AmazonS3Exception
+                    && ((AmazonS3Exception) e).getStatusCode() == HttpStatus.NOT_FOUND.value()) {
+                // A tenant with no buckets is an expected, recoverable condition: the platform
+                // answers with a 404 and OSIS returns an empty list. Log it at DEBUG with a
+                // concise message and no stack trace so the normal "no buckets yet" case does
+                // not read as a failure.
+                logger.debug("Get Bucket List returned no buckets; returning empty list: {}", e.getMessage());
+            } else {
+                // A genuine fault (Vault, S3, network, or auth) stays visible at ERROR with its
+                // stack trace, exactly as before. Only the expected empty-list case above is
+                // quieted; the contract still requires returning an empty page here.
+                logger.error("GetBucketList error. Returning empty list. Error details: ", e);
+            }
             // For errors, GetBucketList should return empty PageOfOsisBucketMeta
             PageInfo pageInfo = new PageInfo(limit, offset);
 

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -1,21 +1,16 @@
 package com.scality.osis.service.impl;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.*;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.amazonaws.Response;
 import com.amazonaws.services.identitymanagement.model.*;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.Owner;
-import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
-import com.amazonaws.services.securitytoken.model.Credentials;
+import com.amazonaws.services.s3.model.*;
+import com.amazonaws.services.securitytoken.model.*;
 import com.scality.osis.model.*;
 import com.scality.osis.model.exception.NotImplementedException;
 import com.scality.osis.utapi.impl.UtapiServiceException;
-import com.scality.osis.utapiclient.dto.ListMetricsRequestDTO;
-import com.scality.osis.utapiclient.dto.MetricsData;
+import com.scality.osis.utapiclient.dto.*;
 import com.scality.osis.vaultadmin.impl.VaultServiceException;
 import com.scality.vaultclient.dto.*;
 
@@ -169,10 +164,10 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         final long limit = 1000L;
         when(s3ClientMock.listBuckets())
                 .thenAnswer((Answer<List<Bucket>>) invocation -> {
-                    final AmazonS3Exception ex = new AmazonS3Exception(
+                    final AmazonS3Exception s3Exception = new AmazonS3Exception(
                             "Requested offset is outside the total available items");
-                    ex.setStatusCode(HttpStatus.BAD_REQUEST.value());
-                    throw ex;
+                    s3Exception.setStatusCode(HttpStatus.BAD_REQUEST.value());
+                    throw s3Exception;
                 });
 
         final PageOfOsisBucketMeta response = scalityOsisServiceUnderTest.getBucketList(SAMPLE_TENANT_ID, offset, limit);
@@ -196,9 +191,9 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         final long limit = 1000L;
         when(s3ClientMock.listBuckets())
                 .thenAnswer((Answer<List<Bucket>>) invocation -> {
-                    final AmazonS3Exception ex = new AmazonS3Exception("The specified bucket does not exist");
-                    ex.setStatusCode(HttpStatus.NOT_FOUND.value());
-                    throw ex;
+                    final AmazonS3Exception s3Exception = new AmazonS3Exception("The specified bucket does not exist");
+                    s3Exception.setStatusCode(HttpStatus.NOT_FOUND.value());
+                    throw s3Exception;
                 });
 
         final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
@@ -251,9 +246,9 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         final long limit = 1000L;
         when(s3ClientMock.listBuckets())
                 .thenAnswer((Answer<List<Bucket>>) invocation -> {
-                    final AmazonS3Exception ex = new AmazonS3Exception("storage platform unavailable");
-                    ex.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
-                    throw ex;
+                    final AmazonS3Exception s3Exception = new AmazonS3Exception("storage platform unavailable");
+                    s3Exception.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                    throw s3Exception;
                 });
 
         final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -1,14 +1,18 @@
 package com.scality.osis.service.impl;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.amazonaws.Response;
 import com.amazonaws.services.identitymanagement.model.*;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.Bucket;
 import com.amazonaws.services.s3.model.Owner;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.scality.osis.model.*;
 import com.scality.osis.model.exception.NotImplementedException;
-import com.scality.osis.s3.impl.S3ServiceException;
 import com.scality.osis.utapi.impl.UtapiServiceException;
 import com.scality.osis.utapiclient.dto.ListMetricsRequestDTO;
 import com.scality.osis.utapiclient.dto.MetricsData;
@@ -19,6 +23,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
 import java.util.ArrayList;
@@ -164,8 +169,10 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         final long limit = 1000L;
         when(s3ClientMock.listBuckets())
                 .thenAnswer((Answer<List<Bucket>>) invocation -> {
-                    throw new S3ServiceException(HttpStatus.BAD_REQUEST,
+                    final AmazonS3Exception ex = new AmazonS3Exception(
                             "Requested offset is outside the total available items");
+                    ex.setStatusCode(HttpStatus.BAD_REQUEST.value());
+                    throw ex;
                 });
 
         final PageOfOsisBucketMeta response = scalityOsisServiceUnderTest.getBucketList(SAMPLE_TENANT_ID, offset, limit);
@@ -175,6 +182,106 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         assertEquals(offset, response.getPageInfo().getOffset());
         assertEquals(limit, response.getPageInfo().getLimit());
         assertEquals(0L, response.getItems().size());
+    }
+
+    /**
+     * A tenant that legitimately has no buckets is an expected, recoverable condition. The
+     * empty-list contract must hold and the recovery must not be logged as an error or
+     * warning, nor dump a stack trace, so operators do not chase a non-failure.
+     */
+    @Test
+    void testGetBucketListEmptyLogsAtDebugWithoutErrorOrTrace() {
+        // Setup: tenant with no buckets surfaces as a 404 from the storage platform
+        final long offset = 0L;
+        final long limit = 1000L;
+        when(s3ClientMock.listBuckets())
+                .thenAnswer((Answer<List<Bucket>>) invocation -> {
+                    final AmazonS3Exception ex = new AmazonS3Exception("The specified bucket does not exist");
+                    ex.setStatusCode(HttpStatus.NOT_FOUND.value());
+                    throw ex;
+                });
+
+        final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
+        final Level originalLevel = serviceLogger.getLevel();
+        // Capture DEBUG so we can assert the expected case is logged there, not at WARN/ERROR.
+        serviceLogger.setLevel(Level.DEBUG);
+        final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        serviceLogger.addAppender(appender);
+
+        try {
+            // Run: empty-list contract must be preserved
+            final PageOfOsisBucketMeta response =
+                    scalityOsisServiceUnderTest.getBucketList(SAMPLE_TENANT_ID, offset, limit);
+
+            assertEquals(0L, response.getPageInfo().getTotal());
+            assertEquals(offset, response.getPageInfo().getOffset());
+            assertEquals(limit, response.getPageInfo().getLimit());
+            assertEquals(0L, response.getItems().size());
+
+            // The expected "no buckets" case must never be logged at ERROR or WARN, and must
+            // not carry a stack trace.
+            assertTrue(appender.list.stream().noneMatch(e -> e.getLevel() == Level.ERROR),
+                    "the expected empty-bucket case must not be logged at ERROR");
+            assertTrue(appender.list.stream().noneMatch(e -> e.getLevel() == Level.WARN),
+                    "the expected empty-bucket case must not be logged at WARN");
+            assertTrue(appender.list.stream().allMatch(e -> e.getThrowableProxy() == null),
+                    "the expected empty-bucket case must not dump a stack trace");
+
+            // The recovery line is emitted, at DEBUG, with the concise message.
+            assertTrue(appender.list.stream()
+                            .anyMatch(e -> e.getLevel() == Level.DEBUG
+                                    && e.getFormattedMessage().contains("returning empty list")),
+                    "the empty-bucket recovery should be logged once at DEBUG");
+        } finally {
+            serviceLogger.detachAppender(appender);
+            serviceLogger.setLevel(originalLevel);
+        }
+    }
+
+    /**
+     * Only the expected empty-bucket 404 is quieted to DEBUG. A genuine fault (here a 500 from
+     * the storage platform) stays visible at ERROR with its stack trace, exactly as before, while
+     * the empty-page contract is still honored.
+     */
+    @Test
+    void testGetBucketListGenuineFaultLogsAtError() {
+        // Setup: a non-404 fault from the storage platform (genuine failure, not "no buckets")
+        final long offset = 0L;
+        final long limit = 1000L;
+        when(s3ClientMock.listBuckets())
+                .thenAnswer((Answer<List<Bucket>>) invocation -> {
+                    final AmazonS3Exception ex = new AmazonS3Exception("storage platform unavailable");
+                    ex.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                    throw ex;
+                });
+
+        final Logger serviceLogger = (Logger) LoggerFactory.getLogger(ScalityOsisServiceImpl.class);
+        final Level originalLevel = serviceLogger.getLevel();
+        serviceLogger.setLevel(Level.DEBUG);
+        final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        serviceLogger.addAppender(appender);
+
+        try {
+            // Contract: still an empty page for the caller
+            final PageOfOsisBucketMeta response =
+                    scalityOsisServiceUnderTest.getBucketList(SAMPLE_TENANT_ID, offset, limit);
+            assertEquals(0L, response.getItems().size());
+
+            // A genuine (non-404) fault must surface at ERROR with its stack trace, not be hidden at DEBUG.
+            assertTrue(appender.list.stream()
+                            .anyMatch(e -> e.getLevel() == Level.ERROR
+                                    && e.getThrowableProxy() != null),
+                    "a genuine bucket-list fault must be logged at ERROR with a stack trace");
+            assertTrue(appender.list.stream()
+                            .noneMatch(e -> e.getLevel() == Level.DEBUG
+                                    && e.getFormattedMessage().contains("no buckets")),
+                    "a genuine fault must not be misreported as the expected no-buckets case");
+        } finally {
+            serviceLogger.detachAppender(appender);
+            serviceLogger.setLevel(originalLevel);
+        }
     }
 
 


### PR DESCRIPTION
## Intent: why does this change exist?
getBucketList returns an empty page when a tenant has no buckets, but the catch logged every case at ERROR with a stack trace, so the normal "no buckets yet" case looked like a failure and muddied diagnosis.

## System impact: what's affected, including downstream?
Logging classification inside getBucketList only. The empty PageOfOsisBucketMeta return contract is unchanged.

## Preserved behavior: what explicitly stays the same?
The empty-list contract is unchanged, and genuine faults (Vault, S3, network, auth) still log at ERROR with their stack trace exactly as before. Only the expected empty case is reclassified.

## Intended change: what's different after this PR?
An expected empty list (an AmazonS3Exception with a 404 status, the type AmazonS3.listBuckets actually throws) is logged at DEBUG with a concise message and no stack trace. Tests pin DEBUG and no-trace for the empty case, and ERROR with a trace for a genuine fault.

## Verification: how do we know this worked, or how would we know if it didn't?
Ran the full osis-core test module including the JaCoCo gate: green. The tests fail if the empty case logs at ERROR or WARN or carries a trace, or if a genuine fault stops logging at ERROR.
