### PR TITLE
OSIS-165: cap getCredentials access-denied recovery to a single retry

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -1262,28 +1262,42 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
      * @return the credentials
      */
     public Credentials getCredentials(String accountID) {
-        Credentials credentials = null;
         try {
-            AssumeRoleRequest assumeRoleRequest = ScalityModelConverter.getAssumeRoleRequestForAccount(accountID,
-                    appEnv.getAssumeRoleName());
-            logger.debug("[Vault] Assume Role request:{}", assumeRoleRequest);
-            credentials = vaultAdmin.getTempAccountCredentials(assumeRoleRequest);
-            logger.debug("[Vault] Assume Role response received with access key:{}, expiration:{}",
-                    credentials.getAccessKeyId(), credentials.getExpiration());
+            return assumeRole(accountID);
         } catch (VaultServiceException e) {
-
-            if (!StringUtils.isNullOrEmpty(e.getErrorCode()) &&
-                    ACCESS_DENIED.equals(e.getErrorCode())) {
-                // if access denied, invoke setupAssumeRole
-                logger.error(e.getReason() + ". Recreating the role");
-                // Call get Account with Account ID to retrieve account name
-                AccountData account = vaultAdmin.getAccount(ScalityModelConverter.toGetAccountRequestWithID(accountID));
-                asyncScalityOsisService.setupAssumeRole(accountID, account.getName());
-                return getCredentials(accountID);
+            if (!isAccessDenied(e)) {
+                throw e;
             }
-            throw e;
+            // if access denied, the osis role is not provisioned yet: set it up and retry once
+            logger.error(e.getReason() + ". Recreating the role");
+            // Call get Account with Account ID to retrieve account name
+            AccountData account = vaultAdmin.getAccount(ScalityModelConverter.toGetAccountRequestWithID(accountID));
+            asyncScalityOsisService.setupAssumeRole(accountID, account.getName());
+
+            try {
+                return assumeRole(accountID);
+            } catch (VaultServiceException retryError) {
+                if (isAccessDenied(retryError)) {
+                    logger.error("Assume role still access-denied for account {} after recreating the role; "
+                            + "giving up to avoid unbounded retries", accountID);
+                }
+                throw retryError;
+            }
         }
+    }
+
+    private Credentials assumeRole(String accountID) {
+        AssumeRoleRequest assumeRoleRequest = ScalityModelConverter.getAssumeRoleRequestForAccount(accountID,
+                appEnv.getAssumeRoleName());
+        logger.debug("[Vault] Assume Role request:{}", assumeRoleRequest);
+        Credentials credentials = vaultAdmin.getTempAccountCredentials(assumeRoleRequest);
+        logger.debug("[Vault] Assume Role response received with access key:{}, expiration:{}",
+                credentials.getAccessKeyId(), credentials.getExpiration());
         return credentials;
+    }
+
+    private boolean isAccessDenied(VaultServiceException e) {
+        return !StringUtils.isNullOrEmpty(e.getErrorCode()) && ACCESS_DENIED.equals(e.getErrorCode());
     }
 
     /**

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceMiscTests.java
@@ -26,7 +26,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import static com.scality.osis.utils.ScalityConstants.IAM_PREFIX;
+import static com.scality.osis.utils.ScalityConstants.*;
 import static com.scality.osis.utils.ScalityTestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -469,6 +469,25 @@ class ScalityOsisServiceMiscTests extends BaseOsisServiceTest {
         assertThrows(VaultServiceException.class, () -> scalityOsisServiceUnderTest.getCredentials(TEST_TENANT_ID));
 
         // Verify the results
+    }
+
+    @Test
+    void testGetCredentialsStopsRetryingWhenAccessDeniedPersists() {
+        // Setup: every assume-role attempt returns access-denied (persistent Vault misconfiguration)
+        when(vaultAdminMock.getTempAccountCredentials(any(AssumeRoleRequest.class)))
+                .thenThrow(new VaultServiceException(HttpStatus.FORBIDDEN, ACCESS_DENIED,
+                        "User: backbeat is not allowed to assume role"));
+
+        // Run the test: persistent access-denied must surface as a VaultServiceException, not recurse forever
+        final VaultServiceException error = assertThrows(VaultServiceException.class,
+                () -> scalityOsisServiceUnderTest.getCredentials(TEST_TENANT_ID));
+
+        // Verify the results
+        assertEquals(ACCESS_DENIED, error.getErrorCode(), "Invalid Error Code");
+        // recovery routine (setupAssumeRole) is reached exactly once: it looks up the account name once
+        verify(vaultAdminMock, times(1)).getAccount(any(GetAccountRequestDTO.class));
+        // exactly one recovery means one original attempt plus one retry, no unbounded recursion
+        verify(vaultAdminMock, times(2)).getTempAccountCredentials(any(AssumeRoleRequest.class));
     }
 
     @Test


### PR DESCRIPTION
## Intent: why does this change exist?
getCredentials recovers from an access-denied assume-role by provisioning the role and retrying, but it retried by calling itself recursively with no depth limit. A persistently misconfigured Vault role would recurse until the stack overflows.

## System impact: what's affected, including downstream?
The assume-role credential path used by all user and S3-credential APIs. Behavior is unchanged on the happy path and on the first recovery; only the unbounded retry is capped.

## Preserved behavior: what explicitly stays the same?
On the first access-denied the role is still provisioned via setupAssumeRole and the assume-role is retried; non-access-denied errors still rethrow immediately. Caches, policies, and the order of calls are unchanged.

## Intended change: what's different after this PR?
Recovery is capped at a single retry: original attempt, provision once, retry once; if it is still access-denied the VaultServiceException is rethrown instead of recursing. The retry path no longer calls getCredentials, so it cannot loop. A test pins that persistent access-denied throws after exactly one provision and two assume-role attempts.

## Verification: how do we know this worked, or how would we know if it didn't?
Ran the full osis-core test module including the JaCoCo gate: green. The new test would fail (or overflow the stack) if the recursion returned.
