### PR TITLE
OSIS-166: preserve Vault server faults (5xx), map other create/update failures to 400

### DIFF
--- a/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
+++ b/osis-core/src/main/java/com/scality/osis/service/impl/ScalityOsisServiceImpl.java
@@ -97,6 +97,20 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
     }
 
     /**
+     * Builds the exception to surface for a failed create/update operation. A genuine Vault server
+     * fault (a {@link VaultServiceException} with a 5xx status) is returned unchanged so the real
+     * server status is preserved. Every other failure is treated as a client-side rejection and
+     * mapped to {@code 400 BAD_REQUEST}, keeping the original exception as the cause.
+     */
+    private VaultServiceException toResponseException(Exception e) {
+        if (e instanceof VaultServiceException
+                && ((VaultServiceException) e).getStatus().is5xxServerError()) {
+            return (VaultServiceException) e;
+        }
+        return new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+    }
+
+    /**
      * Create a tenant in the platform
      *
      * @param osisTenant Tenant to create in the platform (required)
@@ -123,10 +137,8 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             return resOsisTenant;
         } catch (VaultServiceException e) {
-            // Create Tenant supports only 400:BAD_REQUEST error, change status code in the
-            // VaultServiceException
             logger.error("Create Tenant error. Error details: ", e);
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            throw toResponseException(e);
         }
     }
 
@@ -274,10 +286,8 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                     e = ex;
                 }
             }
-            // Create User supports only 400:BAD_REQUEST error, change status code in the
-            // VaultServiceException
             logger.error("Create User error. Error details: ", e);
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            throw toResponseException(e);
         }
 
     }
@@ -432,9 +442,8 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
                 }
             }
 
-            // Create S3 Credential supports only 400:BAD_REQUEST error
             logger.error("Create S3 Credential error. Error details: ", e);
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            throw toResponseException(e);
         }
     }
 
@@ -595,9 +604,12 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
 
             return resOsisTenant;
         } catch (VaultServiceException e) {
-            // Update Tenant supports only 400:BAD_REQUEST error, change status code in the
-            // VaultServiceException
+            // 5xx Vault faults are rethrown as-is; other failures map to 400, keeping the
+            // errorCode/reason for the response contract.
             logger.error("Update Tenant error. Error details: ", e);
+            if (e.getStatus().is5xxServerError()) {
+                throw e;
+            }
             throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getErrorCode(), e.getReason());
         }
     }
@@ -1042,7 +1054,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             }
 
             logger.error("UpdateCredentialStatus error. Error details: ", e);
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            throw toResponseException(e);
         }
     }
 
@@ -1154,7 +1166,7 @@ public class ScalityOsisServiceImpl implements ScalityOsisService {
             }
 
             logger.error("Update User error. Error details: ", e);
-            throw new VaultServiceException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+            throw toResponseException(e);
         }
     }
 

--- a/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
+++ b/osis-core/src/test/java/com/scality/osis/service/impl/ScalityOsisServiceTenantTests.java
@@ -79,6 +79,22 @@ class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
     }
 
     @Test
+    void testCreateTenant500PreservesServerFault() {
+
+        when(vaultAdminMock.createAccount(any(CreateAccountRequestDTO.class)))
+                .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
+                    throw new VaultServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "Vault unavailable");
+                });
+
+        final VaultServiceException exception = assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.createTenant(createSampleOsisTenantObj());
+        });
+
+        assertEquals(500, exception.getStatus().value(),
+                "a genuine Vault server fault must be thrown as its original 500 error code");
+    }
+
+    @Test
     void testListTenants() {
         // Setup
         final long offset = 0L;
@@ -322,6 +338,22 @@ class ScalityOsisServiceTenantTests extends BaseOsisServiceTest {
 
         assertEquals(400, exception.getStatus().value());
         assertEquals("E_BAD_REQUEST", exception.getErrorCode());
+    }
+
+    @Test
+    void testUpdateTenant500PreservesServerFault() {
+        // A matching request passes the name/ID consistency check and reaches the Vault call.
+        when(vaultAdminMock.updateAccountAttributes(any(UpdateAccountAttributesRequestDTO.class)))
+                .thenAnswer((Answer<CreateAccountResponseDTO>) invocation -> {
+                    throw new VaultServiceException(HttpStatus.INTERNAL_SERVER_ERROR, "Vault unavailable");
+                });
+
+        final VaultServiceException exception = assertThrows(VaultServiceException.class, () -> {
+            scalityOsisServiceUnderTest.updateTenant(SAMPLE_ID, createSampleOsisTenantObj());
+        });
+
+        assertEquals(500, exception.getStatus().value(),
+                "a genuine Vault server fault must be thrown as its original 500 error code");
     }
 
     @Test


### PR DESCRIPTION
## Intent: why does this change exist?
Several create and update methods caught any failure and rethrew it as 400 BAD_REQUEST, which masked a genuine Vault server fault (5xx) as a client error and hid real outages behind a misleading status.

## System impact: what's affected, including downstream?
The error status surfaced by createTenant, createUser, createS3Credential, updateTenant, updateCredentialStatus, and updateUser. VaultServiceException extends Spring's ResponseStatusException, so the carried status is what the caller sees.

## Preserved behavior: what explicitly stays the same?
Client-side rejections still map to 400 with the original kept as the cause (updateTenant keeps its errorCode and reason), and all existing error logging is unchanged. Only genuine 5xx faults change.

## Intended change: what's different after this PR?
A VaultServiceException carrying a 5xx status is rethrown unchanged so the real server status reaches the caller, instead of being downgraded to 400. A small toResponseException helper centralizes the rule; updateTenant gets an inline 5xx passthrough to keep its errorCode and reason contract. Tests pin that a 500 from Vault stays 500 on create and update.

## Verification: how do we know this worked, or how would we know if it didn't?
Ran the full osis-core test module including the JaCoCo gate: green. The new tests fail if a Vault 5xx is downgraded to 400.
