### PR TITLE
OSIS-169: Bump review workflow to v2.8.5 to test opus 4.8 availability

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: scality/workflows/.github/workflows/claude-code-review.yml@v2
+    uses: scality/workflows/.github/workflows/claude-code-review.yml@v2.8.5
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
Testing, will revert to v2 in next PR.
I need the PR to be merged to test the change